### PR TITLE
Getting a proper node id with IsNodeHovered function

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1675,7 +1675,8 @@ bool IsNodeHovered(int* const node_id)
     const bool is_hovered = g.node_hovered != INVALID_INDEX;
     if (is_hovered)
     {
-        *node_id = g.node_hovered;
+        const EditorContext& editor = editor_context_get();
+        *node_id = editor.nodes.pool[g.node_hovered].id;
         return true;
     }
     return false;


### PR DESCRIPTION
Just noticed this small bug when getting a hovered node with IsNodeHovered function :P 
Thank you so much for creating this extension btw!