### PR TITLE
Fixes a problem with selections

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1432,7 +1432,7 @@ void EndNodeEditor()
     const ImGuiIO& imgui_io = ImGui::GetIO();
 
     // check to see if the mouse was near any node
-    if (g.node_hovered == INVALID_INDEX)
+    if (g.node_hovered == INVALID_INDEX && ImGui::IsWindowHovered())
     {
         if (is_mouse_clicked)
         {
@@ -1448,7 +1448,7 @@ void EndNodeEditor()
         }
     }
 
-    if (g.link_hovered == INVALID_INDEX)
+    if (g.link_hovered == INVALID_INDEX && ImGui::IsWindowHovered())
     {
         if (is_mouse_clicked)
         {


### PR DESCRIPTION
The selected nodes and links are cleared no matter what window you click in.
This was a problem for me because i had a property window for selected nodes, and whenever i would click in that window to edit a property, it would unselect the node (and links).
This makes it so the click has to happen in the node editor window to cause unselection.
Fixes this issue: https://github.com/Nelarius/imnodes/issues/22