### PR TITLE
Remove pin switch when creating link

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -718,10 +718,6 @@ void begin_link_interaction(EditorContext& editor, const int link_idx)
     {
         ClickInteractionState& state = editor.click_interaction_state;
         const LinkData& link = editor.links.pool[link_idx];
-        state.link_creation.start_pin_idx =
-            g.hovered_pin_idx == link.start_pin_idx ? link.end_pin_idx
-                                                    : link.start_pin_idx;
-
         g.deleted_link_idx = link_idx;
     }
     else


### PR DESCRIPTION
I found that when I tried to create multiple connections from one node to other, it would drag the link from nodes that were already connected, I found that there was a unexpected switch of start and end pins that did this, I removed it in this PR.

Following are some gifs demonstrating the incorrect behavior and correct behavior after this PR.

Incorrect behavior (trying to connect the first node to the third one):
![graph](https://user-images.githubusercontent.com/5235838/80259914-f4dbb300-8686-11ea-9c3b-4102b92ff339.gif)

Correct behavior (successfully connecting the first node to the third one):
![graph2](https://user-images.githubusercontent.com/5235838/80259951-0cb33700-8687-11ea-9f24-0cc57e701ab4.gif)
