### PR TITLE
Don't snap links between pins of the same type & Add more info to IsLinkDropped()

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -952,7 +952,7 @@ void click_interaction_update(EditorContext& editor)
 
         // If we are within the hover radius of a receiving pin, snap the link
         // endpoint to it
-        const ImVec2 end_pos = g.hovered_pin_idx.has_value()
+        const ImVec2 end_pos = (g.hovered_pin_idx.has_value() && editor.pins.pool[g.hovered_pin_idx.value()].type != pin.type)
                                    ? get_screen_space_pin_coordinates(
                                          editor, editor.pins.pool[g.hovered_pin_idx.value()])
                                    : ImGui::GetIO().MousePos;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1050,6 +1050,17 @@ inline ImVec2 get_node_content_origin(const NodeData& node)
     return node.origin + title_bar_height + node.layout_style.padding;
 }
 
+inline ImRect get_node_title_rect(const NodeData& node)
+{
+    ImRect expanded_title_rect = node.title_bar_content_rect;
+    expanded_title_rect.Expand(node.layout_style.padding);
+
+    return ImRect(
+        expanded_title_rect.Min,
+        expanded_title_rect.Min + ImVec2(node.rect.GetWidth(), 0.f) +
+            ImVec2(0.f, expanded_title_rect.GetHeight()));
+}
+
 void draw_grid(EditorContext& editor, const ImVec2& canvas_size)
 {
     const ImVec2 offset = editor.panning;
@@ -1258,13 +1269,7 @@ void draw_node(EditorContext& editor, const int node_idx)
         // title bar:
         if (node.title_bar_content_rect.GetHeight() > 0.f)
         {
-            ImRect expanded_title_rect = node.title_bar_content_rect;
-            expanded_title_rect.Expand(node.layout_style.padding);
-
-            ImRect title_bar_rect = ImRect(
-                expanded_title_rect.Min,
-                expanded_title_rect.Min + ImVec2(node.rect.GetWidth(), 0.f) +
-                    ImVec2(0.f, expanded_title_rect.GetHeight()));
+            ImRect title_bar_rect = get_node_title_rect(node);
 
             g.canvas_draw_list->AddRectFilled(
                 title_bar_rect.Min,
@@ -1725,6 +1730,8 @@ void EndNodeTitleBar()
     EditorContext& editor = editor_context_get();
     NodeData& node = editor.nodes.pool[g.current_node_idx];
     node.title_bar_content_rect = get_item_rect();
+
+    ImGui::ItemAdd(get_node_title_rect(node), ImGui::GetID("title_bar"));
 
     ImGui::SetCursorPos(grid_space_to_editor_space(get_node_content_origin(node)));
 }

--- a/imnodes.h
+++ b/imnodes.h
@@ -260,7 +260,7 @@ bool IsAnyAttributeActive(int* attribute_id = 0);
 // Did the user start dragging a new link from a pin?
 bool IsLinkStarted(int* started_at_attribute_id);
 // Did the user drop the dragged link before attaching it to a pin?
-bool IsLinkDropped();
+bool IsLinkDropped(int* started_at_id = nullptr, bool including_detached_links = true);
 // Did the user finish creating a new link?
 bool IsLinkCreated(int* started_at_attribute_id, int* ended_at_attribute_id);
 // Was an existing link detached from a pin by the user? The detached link's id is assigned to the

--- a/imnodes.h
+++ b/imnodes.h
@@ -260,7 +260,7 @@ bool IsAnyAttributeActive(int* attribute_id = 0);
 // Did the user start dragging a new link from a pin?
 bool IsLinkStarted(int* started_at_attribute_id);
 // Did the user drop the dragged link before attaching it to a pin?
-bool IsLinkDropped(int* started_at_id = nullptr, bool including_detached_links = true);
+bool IsLinkDropped(int* started_at_attribute_id = 0, bool including_detached_links = true);
 // Did the user finish creating a new link?
 bool IsLinkCreated(int* started_at_attribute_id, int* ended_at_attribute_id);
 // Was an existing link detached from a pin by the user? The detached link's id is assigned to the


### PR DESCRIPTION
I don't think linking pins of the same type is ever a desired behaviour?