### PR TITLE
Added new AttributeFlag EnableLinkCreationOnSnap

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -994,7 +994,7 @@ void click_interaction_update(EditorContext& editor)
             g.style.link_thickness,
             link_data.num_segments);
 
-        const bool link_creation_on_snap = 
+        const bool link_creation_on_snap = g.hovered_pin_idx.has_value() &&
             (editor.pins.pool[g.hovered_pin_idx.value()].flags & AttributeFlags_EnableLinkCreationOnSnap);
 
         if (!should_snap)
@@ -1875,10 +1875,10 @@ void Link(int id, const int start_attr_id, const int end_attr_id)
     // Check if this link was created by the current link event
     if (editor.click_interaction_type == ClickInteractionType_LinkCreation &&
         editor.pins.pool[link.end_pin_idx].flags & AttributeFlags_EnableLinkCreationOnSnap &&
-       (editor.click_interaction_state.link_creation.start_pin_idx == link.start_pin_idx &&
-        editor.click_interaction_state.link_creation.end_pin_idx == link.end_pin_idx) ||
+      ((editor.click_interaction_state.link_creation.start_pin_idx == link.start_pin_idx &&
+        editor.click_interaction_state.link_creation.end_pin_idx   == link.end_pin_idx) ||
        (editor.click_interaction_state.link_creation.start_pin_idx == link.end_pin_idx &&
-        editor.click_interaction_state.link_creation.end_pin_idx == link.start_pin_idx))
+        editor.click_interaction_state.link_creation.end_pin_idx   == link.start_pin_idx)))
     {
         g.snap_link_idx = editor.links.find_or_create_index_for(id);
     }

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -952,7 +952,7 @@ void click_interaction_update(EditorContext& editor)
 
         // If we are within the hover radius of a receiving pin, snap the link
         // endpoint to it
-        const ImVec2 end_pos = g.hovered_pin_idx.has_value()
+        const ImVec2 end_pos = (g.hovered_pin_idx.has_value() && editor.pins.pool[g.hovered_pin_idx.value()].type != pin.type)
                                    ? get_screen_space_pin_coordinates(
                                          editor, editor.pins.pool[g.hovered_pin_idx.value()])
                                    : ImGui::GetIO().MousePos;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1050,6 +1050,17 @@ inline ImVec2 get_node_content_origin(const NodeData& node)
     return node.origin + title_bar_height + node.layout_style.padding;
 }
 
+inline ImRect get_node_title_rect(const NodeData& node)
+{
+    ImRect expanded_title_rect = node.title_bar_content_rect;
+    expanded_title_rect.Expand(node.layout_style.padding);
+
+    return ImRect(
+        expanded_title_rect.Min,
+        expanded_title_rect.Min + ImVec2(node.rect.GetWidth(), 0.f) +
+            ImVec2(0.f, expanded_title_rect.GetHeight()));
+}
+
 void draw_grid(EditorContext& editor, const ImVec2& canvas_size)
 {
     const ImVec2 offset = editor.panning;
@@ -1258,13 +1269,7 @@ void draw_node(EditorContext& editor, const int node_idx)
         // title bar:
         if (node.title_bar_content_rect.GetHeight() > 0.f)
         {
-            ImRect expanded_title_rect = node.title_bar_content_rect;
-            expanded_title_rect.Expand(node.layout_style.padding);
-
-            ImRect title_bar_rect = ImRect(
-                expanded_title_rect.Min,
-                expanded_title_rect.Min + ImVec2(node.rect.GetWidth(), 0.f) +
-                    ImVec2(0.f, expanded_title_rect.GetHeight()));
+            ImRect title_bar_rect = get_node_title_rect(node);
 
             g.canvas_draw_list->AddRectFilled(
                 title_bar_rect.Min,
@@ -1725,6 +1730,8 @@ void EndNodeTitleBar()
     EditorContext& editor = editor_context_get();
     NodeData& node = editor.nodes.pool[g.current_node_idx];
     node.title_bar_content_rect = get_item_rect();
+
+    ImGui::ItemAdd(get_node_title_rect(node), ImGui::GetID("title_bar"));
 
     ImGui::SetCursorPos(grid_space_to_editor_space(get_node_content_origin(node)));
 }

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -994,10 +994,24 @@ void click_interaction_update(EditorContext& editor)
             g.style.link_thickness,
             link_data.num_segments);
 
-        if (left_mouse_released ||
-            (should_snap && editor.pins.pool[g.hovered_pin_idx.value()].flags &
-                                AttributeFlags_EnableLinkCreationOnSnap))
+        const bool link_creation_on_snap = 
+            (editor.pins.pool[g.hovered_pin_idx.value()].flags & AttributeFlags_EnableLinkCreationOnSnap);
+
+        if (!should_snap)
         {
+            editor.click_interaction_state.link_creation.end_pin_idx.reset();
+        }
+
+        if (left_mouse_released || (link_creation_on_snap && should_snap))
+        {
+            // Avoid send OnLinkCreated() events every frame if the snap link is not saved
+            // (only applies for EnableLinkCreationOnSnap)
+            if (!left_mouse_released &&
+                editor.click_interaction_state.link_creation.end_pin_idx == g.hovered_pin_idx)
+            {
+                break;
+            }
+
             const bool link_created_succesfully =
                 finish_link_at_hovered_pin(editor, g.hovered_pin_idx);
 

--- a/imnodes.h
+++ b/imnodes.h
@@ -260,7 +260,7 @@ bool IsAnyAttributeActive(int* attribute_id = 0);
 // Did the user start dragging a new link from a pin?
 bool IsLinkStarted(int* started_at_attribute_id);
 // Did the user drop the dragged link before attaching it to a pin?
-bool IsLinkDropped();
+bool IsLinkDropped(int* started_at_id = nullptr, bool including_detached_links = true);
 // Did the user finish creating a new link?
 bool IsLinkCreated(int* started_at_attribute_id, int* ended_at_attribute_id);
 // Was an existing link detached from a pin by the user? The detached link's id is assigned to the

--- a/imnodes.h
+++ b/imnodes.h
@@ -69,7 +69,13 @@ enum AttributeFlags
     // Allow detaching a link by left-clicking and dragging the link at a pin it is connected to.
     // NOTE: the user has to actually delete the link for this to work. A deleted link can be
     // detected by calling IsLinkDestroyed() after EndNodeEditor().
-    AttributeFlags_EnableLinkDetachWithDragClick = 1 << 0
+    AttributeFlags_EnableLinkDetachWithDragClick = 1 << 0,
+    // Visual snapping of an in progress link will trigger IsLink Created/Destroyed events.
+    // Allows for previewing the creation of a link while dragging it across attributes.
+    // See here for demo: https://github.com/Nelarius/imnodes/issues/41#issuecomment-647132113
+    // NOTE: the user has to actually delete the link for this to work. A deleted link can be
+    // detected by calling IsLinkDestroyed() after EndNodeEditor().
+    AttributeFlags_EnableLinkCreationOnSnap = 1 << 1
 };
 
 struct IO
@@ -262,7 +268,7 @@ bool IsLinkStarted(int* started_at_attribute_id);
 // Did the user drop the dragged link before attaching it to a pin?
 bool IsLinkDropped(int* started_at_attribute_id = 0, bool including_detached_links = true);
 // Did the user finish creating a new link?
-bool IsLinkCreated(int* started_at_attribute_id, int* ended_at_attribute_id);
+bool IsLinkCreated(int* started_at_attribute_id, int* ended_at_attribute_id, bool* created_from_snap = 0);
 // Was an existing link detached from a pin by the user? The detached link's id is assigned to the
 // output argument link_id.
 bool IsLinkDestroyed(int* link_id);

--- a/imnodes.h
+++ b/imnodes.h
@@ -260,7 +260,7 @@ bool IsAnyAttributeActive(int* attribute_id = 0);
 // Did the user start dragging a new link from a pin?
 bool IsLinkStarted(int* started_at_attribute_id);
 // Did the user drop the dragged link before attaching it to a pin?
-bool IsLinkDropped(int* started_at_id = nullptr, bool including_detached_links = true);
+bool IsLinkDropped(int* started_at_attribute_id = 0, bool including_detached_links = true);
 // Did the user finish creating a new link?
 bool IsLinkCreated(int* started_at_attribute_id, int* ended_at_attribute_id);
 // Was an existing link detached from a pin by the user? The detached link's id is assigned to the


### PR DESCRIPTION
Followup to https://github.com/Nelarius/imnodes/issues/41

This is a non-breaking change to the imnodes interface. The only changes to the interface are the addition of the AttributeFlag and and optional argument added to `IsLinkCreated()` 

The method I used for getting the link created by the snap in `Link()` feels a bit janky, but it functions as expected and I don't see any other way of getting that info.

I have added light documentation with my changes let me know if you want it explaining further. I've done a reasonable amount of testing and it seems to function fine with all the imnodes features, this is just with my implementation though.