### PR TITLE
added GetNodeDimensions

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -98,6 +98,12 @@ struct ObjectPool
         // set all values to false
         memset(in_use.Data, 0, sizeof(bool) * in_use.size());
     }
+	
+	inline int find(const int id) const
+    {
+		const int index = id_map.GetInt(static_cast<ImGuiID>(id), -1);
+        return index;
+    }
 
     inline int find_or_create_index_for(const int id)
     {
@@ -1770,6 +1776,15 @@ void EndNode()
     g.canvas_draw_list->ChannelsSetCurrent(Channels_NodeBackground);
     draw_node(editor, g.current_node_idx);
     g.canvas_draw_list->ChannelsMerge();
+}
+
+ImVec2 GetNodeDimensions(int node_id)
+{
+    EditorContext& editor = editor_context_get();
+	const int node_idx = editor.nodes.find(node_id);
+    assert(node_id != -1); //invalid node_id
+	const NodeData& node = editor.nodes.pool[node_idx];
+    return ImVec2(node.rect.GetWidth(), node.rect.GetHeight());
 }
 
 void BeginNodeTitleBar()

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1782,9 +1782,9 @@ ImVec2 GetNodeDimensions(int node_id)
 {
     EditorContext& editor = editor_context_get();
 	const int node_idx = editor.nodes.find(node_id);
-    assert(node_id != -1); //invalid node_id
+    assert(node_idx != -1); //invalid node_id
 	const NodeData& node = editor.nodes.pool[node_idx];
-    return ImVec2(node.rect.GetWidth(), node.rect.GetHeight());
+    return node.rect.GetSize();
 }
 
 void BeginNodeTitleBar()

--- a/imnodes.h
+++ b/imnodes.h
@@ -178,6 +178,8 @@ void PopStyleVar();
 void BeginNode(int id);
 void EndNode();
 
+ImVec2 GetNodeDimensions(int id);
+
 // Place your node title bar content (such as the node title, using ImGui::Text) between the
 // following function calls. These functions have to be called before adding any attributes, or the
 // layout of the node will be incorrect.


### PR DESCRIPTION
Returns the screenspace rect of a node
useful if you want to do translate nodes using code (and prevent them from intersecting)
