### PR TITLE
Fix hovering, selection, dragging, and middle-click box selection bugs

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -987,6 +987,11 @@ ImVec2 get_screen_space_pin_coordinates(const EditorContext& editor, const PinDa
 // as C-style free functions so that the code is not too much of a mish-mash of
 // C functions and C++ method definitions.
 
+bool mouse_in_canvas()
+{
+    return g.canvas_rect_screen_space.Contains(ImGui::GetMousePos()) && ImGui::IsWindowHovered();
+}
+
 void begin_node_selection(EditorContext& editor, const int node_idx)
 {
     // Don't start selecting a node if we are e.g. already creating and dragging
@@ -1095,8 +1100,7 @@ void begin_canvas_interaction(EditorContext& editor)
                                         g.hovered_link_idx.has_value() ||
                                         g.hovered_pin_idx.has_value() || ImGui::IsAnyItemHovered();
 
-    const bool mouse_not_in_canvas =
-        !(g.canvas_rect_screen_space.Contains(ImGui::GetMousePos()) && ImGui::IsWindowHovered());
+    const bool mouse_not_in_canvas = !mouse_in_canvas();
 
     if (any_ui_element_hovered || mouse_not_in_canvas)
     {
@@ -1108,8 +1112,10 @@ void begin_canvas_interaction(EditorContext& editor)
             ? (g.left_mouse_clicked && *g.io.emulate_three_button_mouse.modifier)
             : g.middle_mouse_clicked;
 
-    editor.click_interaction_type =
-        started_panning ? ClickInteractionType_Panning : ClickInteractionType_BoxSelection;
+    editor.click_interaction_type = started_panning
+                                        ? ClickInteractionType_Panning
+                                        : g.left_mouse_clicked ? ClickInteractionType_BoxSelection
+                                                               : editor.click_interaction_type;
 
     if (editor.click_interaction_type == ClickInteractionType_BoxSelection)
     {
@@ -1655,6 +1661,11 @@ void draw_pin_shape(const ImVec2& pin_pos, const PinData& pin, const ImU32 pin_c
     }
 }
 
+bool is_pin_hovered(const PinData& pin)
+{
+    return is_mouse_hovering_near_point(pin.pos, g.style.pin_hover_radius);
+}
+
 void draw_pin(EditorContext& editor, const int pin_idx, const bool left_mouse_clicked)
 {
     PinData& pin = editor.pins.pool[pin_idx];
@@ -1664,7 +1675,10 @@ void draw_pin(EditorContext& editor, const int pin_idx, const bool left_mouse_cl
 
     ImU32 pin_color = pin.color_style.background;
 
-    if (is_mouse_hovering_near_point(pin.pos, g.style.pin_hover_radius))
+    const bool pin_hovered = is_pin_hovered(pin) && mouse_in_canvas() &&
+                             editor.click_interaction_type != ClickInteractionType_BoxSelection;
+
+    if (pin_hovered)
     {
         g.hovered_pin_idx = pin_idx;
         g.hovered_pin_flags = pin.flags;
@@ -1679,6 +1693,24 @@ void draw_pin(EditorContext& editor, const int pin_idx, const bool left_mouse_cl
     draw_pin_shape(pin.pos, pin, pin_color);
 }
 
+// TODO: Separate hover code from drawing code to avoid this unpleasant divergent function signature.
+bool is_node_hovered(EditorContext& editor, const int node_idx)
+{
+    // We render pins on top of nodes. In order to prevent node interaction when a pin is on top of
+    // a node, we just early out here if a pin is hovered.
+    const NodeData& node = editor.nodes.pool[node_idx];
+    for (int i = 0; i < node.pin_indices.size(); ++i)
+    {
+        PinData& pin = editor.pins.pool[node.pin_indices[i]];
+        if (is_pin_hovered(pin))
+        {
+            return false;
+        }
+    }
+
+    return g.hovered_node_idx.has_value() && node_idx == g.hovered_node_idx.value();
+}
+
 // TODO: It may be useful to make this an EditorContext method, since this uses
 // a lot of editor state. Currently that is just not clear, since we don't pass
 // the editor as a part of the function signature.
@@ -1687,8 +1719,8 @@ void draw_node(EditorContext& editor, const int node_idx)
     const NodeData& node = editor.nodes.pool[node_idx];
     ImGui::SetCursorPos(node.origin + editor.panning);
 
-    const bool node_hovered =
-        g.hovered_node_idx.has_value() && node_idx == g.hovered_node_idx.value();
+    const bool node_hovered = is_node_hovered(editor, node_idx) && mouse_in_canvas() &&
+                              editor.click_interaction_type != ClickInteractionType_BoxSelection;
 
     ImU32 node_background = node.color_style.background;
     ImU32 titlebar_background = node.color_style.titlebar;
@@ -1750,9 +1782,9 @@ void draw_node(EditorContext& editor, const int node_idx)
 
 bool is_link_hovered(const LinkBezierData& link_data)
 {
-    // We render nodes on top of links. In order to prevent link interaction when a node is on top
-    // of a link, we just early out here if a node is hovered.
-    if (g.hovered_node_idx.has_value())
+    // We render pins and nodes on top of links. In order to prevent link interaction when a pin or
+    // node is on top of a link, we just early out here if a pin or node is hovered.
+    if (g.hovered_pin_idx.has_value() || g.hovered_node_idx.has_value())
     {
         return false;
     }
@@ -1769,7 +1801,9 @@ void draw_link(EditorContext& editor, const int link_idx)
     const LinkBezierData link_data = get_link_renderable(
         start_pin.pos, end_pin.pos, start_pin.type, g.style.link_line_segments_per_length);
 
-    const bool link_hovered = is_link_hovered(link_data);
+    const bool link_hovered = is_link_hovered(link_data) && mouse_in_canvas() &&
+                              editor.click_interaction_type != ClickInteractionType_BoxSelection;
+
     if (link_hovered)
     {
         g.hovered_link_idx = link_idx;
@@ -2105,6 +2139,18 @@ void EndNodeEditor()
         }
     }
 
+    // In order to render the links underneath the nodes, we want to first select the bottom draw
+    // channel.
+    g.canvas_draw_list->ChannelsSetCurrent(0);
+
+    for (int link_idx = 0; link_idx < editor.links.pool.size(); ++link_idx)
+    {
+        if (editor.links.in_use[link_idx])
+        {
+            draw_link(editor, link_idx);
+        }
+    }
+
     // Render the click interaction UI elements (partial links, box selector) on top of everything
     // else.
 
@@ -2125,18 +2171,6 @@ void EndNodeEditor()
     object_pool_update(editor.pins);
 
     draw_list_sort_channels_by_depth(editor.node_depth_order);
-
-    // In order to render the links underneath the nodes, we want to first select the bottom draw
-    // channel.
-    g.canvas_draw_list->ChannelsSetCurrent(0);
-
-    for (int link_idx = 0; link_idx < editor.links.pool.size(); ++link_idx)
-    {
-        if (editor.links.in_use[link_idx])
-        {
-            draw_link(editor, link_idx);
-        }
-    }
 
     // After the links have been rendered, the link pool can be updated as well.
     object_pool_update(editor.links);
@@ -2441,7 +2475,7 @@ ImVec2 GetNodeGridSpacePos(int node_id)
 
 bool IsEditorHovered()
 {
-    return g.canvas_rect_screen_space.Contains(ImGui::GetMousePos()) && ImGui::IsWindowHovered();
+    return mouse_in_canvas();
 }
 
 bool IsNodeHovered(int* const node_id)


### PR DESCRIPTION
The following are possible actions (bugs) that exist in the current codebase:

- You can hover over nodes, links, and pins while mouse is outside of canvas
- You can select nodes and links while mouse is outside of canvas
- You can begin dragging nodes while mouse is outside of canvas
- You can interact with pins (creating a link) while mouse is outside of canvas
- You can hover over nodes, links, pins while performing a box select
- You can hover over pin and node at the same time
- You can hover over pin and link at the same time
- When simulated middle-click is enabled, you can begin a box selection with middle-click that does not finish when middle mouse button is released

This pull request fixes all of these issues. Please let me know if you would like me to make any changes to the pull request.