### PR TITLE
Add grid snapping, primary grid line coloration.

### DIFF
--- a/imnodes.h
+++ b/imnodes.h
@@ -24,6 +24,7 @@ enum ColorStyle
     ColorStyle_BoxSelectorOutline,
     ColorStyle_GridBackground,
     ColorStyle_GridLine,
+    ColorStyle_GridLinePrimary,
     ColorStyle_Count
 };
 
@@ -49,7 +50,9 @@ enum StyleFlags
 {
     StyleFlags_None = 0,
     StyleFlags_NodeOutline = 1 << 0,
-    StyleFlags_GridLines = 1 << 2
+    StyleFlags_GridLines = 1 << 2,
+    StyleFlags_GridLinesPrimary = 1 << 3,
+    StyleFlags_GridSnapping = 1 << 4
 };
 
 // This enum controls the way attribute pins look.


### PR DESCRIPTION
I didn't see any issues related to grid snapping, and since in visual-scripting grid snapping often means the difference between unreadable spaghetti and maintainable graphs, I figured I would try to implement it concisely and upstream it.

![imnodes_snap_preview](https://user-images.githubusercontent.com/4218491/100429788-d518cd00-3063-11eb-9fdf-1ccbc252c81a.gif)

Grid snapping uses a simple nearest-point algorithm that works for negative coordinates. It could be fancier, but that would involve snapping the node's position independent of the actual origin or getting the absolute mouse position and original click position in the node and generating the snap from there. It's totally configurable based on the grid square width and the style flags.

Primary line drawing is very simple, just colors the origin lines a lighter (or darker) shade. Could likely be extended to draw every `n` lines instead, but that's outside of the scope of this PR. It's off by default but controllable with style flags and colors for those who like the UE4 grid drawing and aligning their nodes with the graph origin.

Also fixed an (overlooked) issue where `StyleColorsLight` was clearing the style flags which resulted in a very suboptimal default experience for light-theme users.