### PR TITLE
Fix AttributeFlags_EnableLinkDetachWithDragClick not working

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1791,11 +1791,16 @@ void draw_node(EditorContext& editor, const int node_idx)
     }
 }
 
-bool is_link_hovered(const LinkBezierData& link_data)
+bool is_link_hovered(const LinkData& link, const LinkBezierData& link_data)
 {
     // We render pins and nodes on top of links. In order to prevent link interaction when a pin or
     // node is on top of a link, we just early out here if a pin or node is hovered.
-    if (g.hovered_pin_idx.has_value() || g.hovered_node_idx.has_value())
+    if (g.hovered_pin_idx.has_value() )
+    {
+        // If hovered pin is part of the link consider the link also hovered
+        return g.hovered_pin_idx == link.start_pin_idx || g.hovered_pin_idx == link.end_pin_idx;        
+    }
+    if (g.hovered_node_idx.has_value())
     {
         return false;
     }
@@ -1812,7 +1817,7 @@ void draw_link(EditorContext& editor, const int link_idx)
     const LinkBezierData link_data = get_link_renderable(
         start_pin.pos, end_pin.pos, start_pin.type, g.style.link_line_segments_per_length);
 
-    const bool link_hovered = is_link_hovered(link_data) && mouse_in_canvas() &&
+    const bool link_hovered = is_link_hovered(link, link_data) && mouse_in_canvas() &&
                               editor.click_interaction_type != ClickInteractionType_BoxSelection;
 
     if (link_hovered)

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1083,6 +1083,8 @@ void begin_link_interaction(EditorContext& editor, const int link_idx)
 
             editor.click_interaction_type = ClickInteractionType_LinkCreation;
             begin_link_detach(editor, link_idx, closest_pin_idx);
+            editor.click_interaction_state.link_creation.link_creation_type =
+                LinkCreationType_FromDetach;
         }
         else
         {


### PR DESCRIPTION
For AttributeFlags_EnableLinkDetachWithDragClick to work the link and pin need to be considered hovered, with the fixes to hovering this was no longer possible.

To fix this I changed the link to also be considered hovered if the pins of the link are hovered. This fixes the issue and improves on the detach behaviour. Previously it was only possible to detach a link from the left side of a pin (where the link was also underneath the mouse), now it is possible to detach by clicking anywhere on the pin.