### PR TITLE
Adds function to get node IDs from link ID

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -2777,6 +2777,16 @@ bool IsLinkDestroyed(int* const link_id)
     return link_destroyed;
 }
 
+void GetNodesFromLink(const int link_id, int* const parent_node_id, int* const child_node_id)
+{
+    EditorContext& editor = editor_context_get();
+    LinkData& link = object_pool_find_or_create_object(editor.links, link_id);
+    const PinData& pin_start = editor.pins.pool[link.start_pin_idx];
+    const PinData& pin_end = editor.pins.pool[link.end_pin_idx];
+    *parent_node_id = editor.nodes.pool[pin_start.parent_node_idx].id;
+    *child_node_id = editor.nodes.pool[pin_end.parent_node_idx].id;
+}
+
 namespace
 {
 void node_line_handler(EditorContext& editor, const char* line)

--- a/imnodes.h
+++ b/imnodes.h
@@ -306,6 +306,9 @@ bool IsLinkCreated(
 // output argument link_id.
 bool IsLinkDestroyed(int* link_id);
 
+// Gets connected node IDs from link ID
+void GetNodesFromLink(const int link_id, int* const parent_node_id, int* const child_node_id);
+
 // Use the following functions to write the editor context's state to a string, or directly to a
 // file. The editor context is serialized in the INI file format.
 


### PR DESCRIPTION
In this PR, I've added a simple function that I used to gather a pair IDs associated with nodes connected by a link, given the link's ID.

I'm currently using the function in order to draw linkages in a navigation mini-map, which are then used to lookup the node positions with:
```
ImGui::GetNodeScreenSpacePos(...);
```
My aim was to do so without having to mirror the ID managing structures outside of `imnodes::EditorContext`

Do you think this type of structural introspection function has a place in this library? If not, is there an alternative I might be overlooking?