### PR TITLE
Adds node editor MiniMap feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,44 @@ style.colors[ImNodesCol_TitleBar] = IM_COL32(232, 27, 86, 255);
 style.colors[ImNodesCol_TitleBarSelected] = IM_COL32(241, 108, 146, 255);
 ```
 
+To handle quicker navigation of large graphs you can use an interactive mini-map overlay. The mini-map can be zoomed and scrolled. Editor nodes will track the panning of the mini-map accordingly.
+
+```cpp
+ImGui::Begin("node editor");
+
+ImNodes::BeginNodeEditor();
+
+// add nodes...
+
+// must be called right before EndNodeEditor
+ImNodes::MiniMap();
+ImNodes::EndNodeEditor();
+
+ImGui::End();
+```
+
+The relative sizing and corner location of the mini-map in the editor space can be specified like so:
+
+```cpp
+// MiniMap is a square region with a side length that is 20% the largest editor canvas dimension
+// See ImNodesMiniMapLocation_ for other corner locations
+ImNodes::MiniMap(0.2f, ImNodesMiniMapLocation_TopRight);
+```
+
+The mini-map also supports limited node hovering customization through a user-defined callback.
+```cpp
+// User callback
+void mini_map_node_hovering_callback(int node_id, void* user_data)
+{
+  ImGui::SetTooltip("This is node %d", node_id);
+}
+
+// Later on...
+ImNodes::MiniMap(0.2f, ImNodesMiniMapLocation_TopRight, mini_map_node_hovering_callback, custom_user_data);
+
+// 'custom_user_data' can be used to supply extra information needed for drawing within the callback
+```
+
 ## Known issues
 
 * `ImGui::Separator()` spans the current window span. As a result, using a separator inside a node will result in the separator spilling out of the node into the node editor grid.

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -632,8 +632,7 @@ void BeginCanvasInteraction(ImNodesEditorContext& editor)
     const bool started_panning = GImNodes->AltMouseClicked;
 
     // Handle mini-map interactions
-    if (ImGui::IsWindowFocused() and
-        ImGui::IsMouseHoveringRect(GImNodes->MiniMapRectScreenSpace.Min, GImNodes->MiniMapRectScreenSpace.Max))
+    if (ImGui::IsMouseHoveringRect(GImNodes->MiniMapRectScreenSpace.Min, GImNodes->MiniMapRectScreenSpace.Max))
     {
         if (started_panning)
         {
@@ -1722,7 +1721,6 @@ static void MiniMapDrawNode(ImNodesEditorContext& editor,
     ImU32 mini_map_node_background;
 
     if (editor.ClickInteraction.Type == ImNodesClickInteractionType_None &&
-        ImGui::IsWindowFocused() &&
         ImGui::IsMouseHoveringRect(mini_map_node_min, mini_map_node_max))
     {
         mini_map_node_background = GImNodes->Style.Colors[ImNodesCol_MiniMapNodeBackgroundHovered];
@@ -1818,7 +1816,6 @@ static void MiniMapUpdate()
 
     // NOTE: use normal background when panning (typically opaque)
     if (editor.ClickInteraction.Type != ImNodesClickInteractionType_MiniMapPanning &&
-        ImGui::IsWindowFocused() &&
         ImGui::IsMouseHoveringRect(mini_map_rect.Min, mini_map_rect.Max))
     {
         mini_map_background = GImNodes->Style.Colors[ImNodesCol_MiniMapBackgroundHovered];

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -638,7 +638,7 @@ void BeginCanvasInteraction(ImNodesEditorContext& editor)
         {
             editor.ClickInteraction.Type = ImNodesClickInteractionType_MiniMapPanning;
         }
-        else if (GImNodes->LeftMouseClicked)
+        else if (GImNodes->LeftMouseReleased)
         {
             editor.ClickInteraction.Type = ImNodesClickInteractionType_MiniMapSnapping;
         }
@@ -2206,7 +2206,7 @@ void EndNodeEditor()
     DrawListAppendClickInteractionChannel();
     DrawListActivateClickInteractionChannel();
 
-    if (GImNodes->LeftMouseClicked || GImNodes->AltMouseClicked || GImNodes->AltMouseScrollDelta != 0.f)
+    if (GImNodes->LeftMouseClicked || GImNodes->LeftMouseReleased || GImNodes->AltMouseClicked || GImNodes->AltMouseScrollDelta != 0.f)
     {
         BeginCanvasInteraction(editor);
     }

--- a/imnodes.h
+++ b/imnodes.h
@@ -7,6 +7,7 @@ typedef int ImNodesStyleVar;       // -> enum ImNodesStyleVar_
 typedef int ImNodesStyleFlags;     // -> enum ImNodesStyleFlags_
 typedef int ImNodesPinShape;       // -> enum ImNodesPinShape_
 typedef int ImNodesAttributeFlags; // -> enum ImNodesAttributeFlags_
+typedef int ImNodesMiniMapLocation;// -> enum ImNodesMiniMapLocation_
 
 enum ImNodesCol_
 {
@@ -26,6 +27,16 @@ enum ImNodesCol_
     ImNodesCol_BoxSelectorOutline,
     ImNodesCol_GridBackground,
     ImNodesCol_GridLine,
+    ImNodesCol_MiniMapBackground,
+    ImNodesCol_MiniMapBackgroundHovered,
+    ImNodesCol_MiniMapOutline,
+    ImNodesCol_MiniMapOutlineHovered,
+    ImNodesCol_MiniMapNodeBackground,
+    ImNodesCol_MiniMapNodeBackgroundHovered,
+    ImNodesCol_MiniMapNodeBackgroundSelected,
+    ImNodesCol_MiniMapNodeOutline,
+    ImNodesCol_MiniMapLink,
+    ImNodesCol_MiniMapLinkSelected,
     ImNodesCol_COUNT
 };
 
@@ -159,6 +170,14 @@ struct ImNodesStyle
     ImNodesStyle();
 };
 
+enum ImNodesMiniMapLocation_
+{
+    ImNodesMiniMapLocation_BottomLeft,
+    ImNodesMiniMapLocation_BottomRight,
+    ImNodesMiniMapLocation_TopLeft,
+    ImNodesMiniMapLocation_TopRight,
+};
+
 struct ImGuiContext;
 struct ImVec2;
 
@@ -170,6 +189,9 @@ struct ImNodesContext;
 // By default, the library creates an editor context behind the scenes, so using any of the imnodes
 // functions doesn't require you to explicitly create a context.
 struct ImNodesEditorContext;
+
+// Callback type used to specify special behavior when hovering a node in the minimap
+typedef void (*ImNodesMiniMapNodeHoveringCallback)(int, void*);
 
 namespace ImNodes
 {
@@ -202,6 +224,13 @@ void StyleColorsLight();
 // will result the node editor grid workspace being rendered.
 void BeginNodeEditor();
 void EndNodeEditor();
+
+// Add a navigable minimap to the editor; call before EndNodeEditor after all
+// nodes and links have been specified
+void MiniMap(const float minimap_size_fraction = 0.2f,
+             const ImNodesMiniMapLocation location = ImNodesMiniMapLocation_TopLeft,
+             const ImNodesMiniMapNodeHoveringCallback node_hovering_callback = NULL,
+             void* node_hovering_callback_data = NULL);
 
 // Use PushColorStyle and PopColorStyle to modify ImNodesStyle::Colors mid-frame.
 void PushColorStyle(ImNodesCol item, unsigned int color);

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -56,6 +56,9 @@ enum ImNodesClickInteractionType_
     ImNodesClickInteractionType_LinkCreation,
     ImNodesClickInteractionType_Panning,
     ImNodesClickInteractionType_BoxSelection,
+    ImNodesClickInteractionType_MiniMapPanning,
+    ImNodesClickInteractionType_MiniMapZooming,
+    ImNodesClickInteractionType_MiniMapSnapping,
     ImNodesClickInteractionType_None
 };
 
@@ -64,6 +67,9 @@ enum ImNodesLinkCreationType_
     ImNodesLinkCreationType_Standard,
     ImNodesLinkCreationType_FromDetach
 };
+
+// Callback type used to specify special behavior when hovering a node in the minimap
+typedef void (*ImNodesMiniMapNodeHoveringCallback)(int, void*);
 
 // [SECTION] internal data structures
 
@@ -274,6 +280,13 @@ struct ImNodesContext
     ImVec2 CanvasOriginScreenSpace;
     ImRect CanvasRectScreenSpace;
 
+    // MiniMap state
+    ImRect MiniMapRectScreenSpace;
+    ImVec2 MiniMapRectSnappingOffset;
+    float MiniMapZoom;
+    ImNodesMiniMapNodeHoveringCallback MiniMapNodeHoveringCallback;
+    void* MiniMapNodeHoveringCallbackUserData;
+
     // Debug helpers
     ImNodesScope CurrentScope;
 
@@ -318,6 +331,7 @@ struct ImNodesContext
     bool AltMouseClicked;
     bool LeftMouseDragging;
     bool AltMouseDragging;
+    float AltMouseScrollDelta;
 };
 
 namespace ImNodes


### PR DESCRIPTION
Adds mini map feature to be used between `BeginNodeEditor` and `EndNodeEditor` with following features:
- provides "low detail" view of nodes/links in the graph as an overlay in the editor canvas
- provides the ability to zoom in and out of this context to view more of the graph than is visible in the normal editor canvas viewport
- scrolling, which scales with zoom (when zoomed out, scrolls the editor context at a faster rate)
- node snapping when clicked: pans clicked node to center of canvas when mini-map node is clicked
- node hovering callback, which can be used to set custom tooltips when hovering the mini map
- separate color variables for the mini map bg/outline and nodes/links
- four positioning options within the editor canvas


https://user-images.githubusercontent.com/1093236/114410231-0f40c200-9b60-11eb-9057-44e1ac9bbb66.mp4

