### PR TITLE
Add grid snapping, ctrl-select, primary grid coloration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if (APPLE)
     target_link_libraries(colornode "-framework OpenGL")
 elseif(MSVC)
     target_link_libraries(colornode "opengl32")
+else()
+    target_link_libraries(colornode X11 Xext GL)
 endif()
 
 add_executable(multieditor
@@ -47,6 +49,8 @@ if (APPLE)
     target_link_libraries(multieditor "-framework OpenGL")
 elseif(MSVC)
     target_link_libraries(multieditor "opengl32")
+else()
+    target_link_libraries(multieditor X11 Xext GL)
 endif()
 
 add_executable(saveload
@@ -58,6 +62,8 @@ if (APPLE)
     target_link_libraries(saveload "-framework OpenGL")
 elseif(MSVC)
     target_link_libraries(saveload "opengl32")
+else()
+    target_link_libraries(saveload X11 Xext GL)
 endif()
 
 add_executable(hello
@@ -69,4 +75,6 @@ if (APPLE)
     target_link_libraries(hello "-framework OpenGL")
 elseif(MSVC)
     target_link_libraries(hello "opengl32")
+else()
+    target_link_libraries(hello X11 Xext GL)
 endif()

--- a/example/multi_editor.cpp
+++ b/example/multi_editor.cpp
@@ -46,6 +46,7 @@ void show_editor(const char* editor_name, Editor& editor)
     {
         const int node_id = ++editor.current_id;
         ImNodes::SetNodeScreenSpacePos(node_id, ImGui::GetMousePos());
+        ImNodes::SnapNodeToGrid(node_id);
         editor.nodes.push_back(Node(node_id, 0.f));
     }
 
@@ -120,6 +121,10 @@ void NodeEditorInitialize()
 
     ImNodesIO& io = ImNodes::GetIO();
     io.LinkDetachWithModifierClick.Modifier = &ImGui::GetIO().KeyCtrl;
+    io.MultipleSelectModifier.Modifier = &ImGui::GetIO().KeyCtrl;
+
+    ImNodesStyle& style = ImNodes::GetStyle();
+    style.Flags |= ImNodesStyleFlags_GridLinesPrimary | ImNodesStyleFlags_GridSnapping;
 }
 
 void NodeEditorShow()

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -588,12 +588,16 @@ void BeginNodeSelection(ImNodesEditorContext& editor, const int node_idx)
     // If the node is not already contained in the selection, then we want only
     // the interaction node to be selected, effective immediately.
     //
+    // If the multiple selection modifier is active, we want to add this node
+    // to the current list of selected nodes.
+    //
     // Otherwise, we want to allow for the possibility of multiple nodes to be
     // moved at once.
     if (!editor.SelectedNodeIndices.contains(node_idx))
     {
-        editor.SelectedNodeIndices.clear();
         editor.SelectedLinkIndices.clear();
+        if (!GImNodes->MultipleSelectModifier)
+            editor.SelectedNodeIndices.clear();
         editor.SelectedNodeIndices.push_back(node_idx);
 
         // Ensure that individually selected nodes get rendered on top
@@ -602,6 +606,28 @@ void BeginNodeSelection(ImNodesEditorContext& editor, const int node_idx)
         assert(elem != depth_stack.end());
         depth_stack.erase(elem);
         depth_stack.push_back(node_idx);
+    }
+    // Deselect a previously-selected node
+    else if (GImNodes->MultipleSelectModifier)
+    {
+        const int* const node_ptr = editor.SelectedNodeIndices.find(node_idx);
+        editor.SelectedNodeIndices.erase(node_ptr);
+
+        // Don't allow dragging after deselecting
+        editor.ClickInteraction.Type = ImNodesClickInteractionType_None;
+    }
+
+    // To support snapping of multiple nodes, we need to store the offset of
+    // each node in the selection to the origin of the dragged node.
+    const ImVec2 ref_origin = editor.Nodes.Pool[node_idx].Origin;
+    editor.PrimaryNodeOffset = ref_origin + GImNodes->CanvasOriginScreenSpace + editor.Panning - GImNodes->MousePos;
+
+    editor.SelectedNodeOffsets.clear();
+    for (int idx = 0; idx < editor.SelectedNodeIndices.Size; idx++)
+    {
+        const int    node = editor.SelectedNodeIndices[idx];
+        const ImVec2 node_origin = editor.Nodes.Pool[node].Origin - ref_origin;
+        editor.SelectedNodeOffsets.push_back(node_origin);
     }
 }
 
@@ -778,18 +804,40 @@ void BoxSelectorUpdateSelection(ImNodesEditorContext& editor, ImRect box_rect)
     }
 }
 
+ImVec2 SnapOriginToGrid(ImVec2 origin)
+{
+    if (GImNodes->Style.Flags & ImNodesStyleFlags_GridSnapping)
+    {
+        const float spacing = GImNodes->Style.GridSpacing;
+        const float spacing2 = spacing * 0.5f;
+
+        // Snap the origin to the nearest grid point in any direction
+        float modx = fmodf(fabsf(origin.x) + spacing2, spacing) - spacing2;
+        float mody = fmodf(fabsf(origin.y) + spacing2, spacing) - spacing2;
+        origin.x += (origin.x < 0.f) ? modx : -modx;
+        origin.y += (origin.y < 0.f) ? mody : -mody;
+    }
+
+    return origin;
+}
+
 void TranslateSelectedNodes(ImNodesEditorContext& editor)
 {
     if (GImNodes->LeftMouseDragging)
     {
-        const ImGuiIO& io = ImGui::GetIO();
+        // If we have grid snap enabled, don't start moving nodes until we've moved the mouse slightly
+        const bool shouldTranslate = (GImNodes->Style.Flags & ImNodesStyleFlags_GridSnapping)
+            ? ImGui::GetIO().MouseDragMaxDistanceSqr[0] > 5.0 : true;
+
+        const ImVec2 origin = SnapOriginToGrid(GImNodes->MousePos - GImNodes->CanvasOriginScreenSpace - editor.Panning + editor.PrimaryNodeOffset);
         for (int i = 0; i < editor.SelectedNodeIndices.size(); ++i)
         {
-            const int   node_idx = editor.SelectedNodeIndices[i];
-            ImNodeData& node = editor.Nodes.Pool[node_idx];
-            if (node.Draggable)
+            const ImVec2 node_rel = editor.SelectedNodeOffsets[i];
+            const int    node_idx = editor.SelectedNodeIndices[i];
+            ImNodeData&  node = editor.Nodes.Pool[node_idx];
+            if (node.Draggable && shouldTranslate)
             {
-                node.Origin += io.MouseDelta - editor.AutoPanningDelta;
+                node.Origin = origin + node_rel + editor.AutoPanningDelta;
             }
         }
     }
@@ -1275,6 +1323,9 @@ inline ImRect GetNodeTitleRect(const ImNodeData& node)
 void DrawGrid(ImNodesEditorContext& editor, const ImVec2& canvas_size)
 {
     const ImVec2 offset = editor.Panning;
+    ImU32 line_color = GImNodes->Style.Colors[ImNodesCol_GridLine];
+    ImU32 line_color_prim = GImNodes->Style.Colors[ImNodesCol_GridLinePrimary];
+    bool draw_primary = GImNodes->Style.Flags & ImNodesStyleFlags_GridLinesPrimary;
 
     for (float x = fmodf(offset.x, GImNodes->Style.GridSpacing); x < canvas_size.x;
          x += GImNodes->Style.GridSpacing)
@@ -1282,7 +1333,7 @@ void DrawGrid(ImNodesEditorContext& editor, const ImVec2& canvas_size)
         GImNodes->CanvasDrawList->AddLine(
             EditorSpaceToScreenSpace(ImVec2(x, 0.0f)),
             EditorSpaceToScreenSpace(ImVec2(x, canvas_size.y)),
-            GImNodes->Style.Colors[ImNodesCol_GridLine]);
+            offset.x - x == 0.f && draw_primary ? line_color_prim : line_color);
     }
 
     for (float y = fmodf(offset.y, GImNodes->Style.GridSpacing); y < canvas_size.y;
@@ -1291,7 +1342,7 @@ void DrawGrid(ImNodesEditorContext& editor, const ImVec2& canvas_size)
         GImNodes->CanvasDrawList->AddLine(
             EditorSpaceToScreenSpace(ImVec2(0.0f, y)),
             EditorSpaceToScreenSpace(ImVec2(canvas_size.x, y)),
-            GImNodes->Style.Colors[ImNodesCol_GridLine]);
+            offset.y - y == 0.f && draw_primary ? line_color_prim : line_color);
     }
 }
 
@@ -1926,6 +1977,8 @@ ImNodesIO::EmulateThreeButtonMouse::EmulateThreeButtonMouse() : Modifier(NULL) {
 
 ImNodesIO::LinkDetachWithModifierClick::LinkDetachWithModifierClick() : Modifier(NULL) {}
 
+ImNodesIO::MultipleSelectModifier::MultipleSelectModifier() : Modifier(NULL) {}
+
 ImNodesIO::ImNodesIO()
     : EmulateThreeButtonMouse(), LinkDetachWithModifierClick(),
       AltMouseButton(ImGuiMouseButton_Middle), AutoPanningSpeed(1000.0f)
@@ -1933,7 +1986,7 @@ ImNodesIO::ImNodesIO()
 }
 
 ImNodesStyle::ImNodesStyle()
-    : GridSpacing(32.f), NodeCornerRounding(4.f), NodePadding(8.f, 8.f), NodeBorderThickness(1.f),
+    : GridSpacing(24.f), NodeCornerRounding(4.f), NodePadding(8.f, 8.f), NodeBorderThickness(1.f),
       LinkThickness(3.f), LinkLineSegmentsPerLength(0.1f), LinkHoverDistance(10.f),
       PinCircleRadius(4.f), PinQuadSideLength(7.f), PinTriangleSideLength(9.5),
       PinLineThickness(1.f), PinHoverRadius(10.f), PinOffset(0.f), MiniMapPadding(8.0f, 8.0f),
@@ -2032,6 +2085,7 @@ void StyleColorsDark()
 
     GImNodes->Style.Colors[ImNodesCol_GridBackground] = IM_COL32(40, 40, 50, 200);
     GImNodes->Style.Colors[ImNodesCol_GridLine] = IM_COL32(200, 200, 200, 40);
+    GImNodes->Style.Colors[ImNodesCol_GridLinePrimary] = IM_COL32(240, 240, 240, 60);
 
     // minimap colors
     GImNodes->Style.Colors[ImNodesCol_MiniMapBackground] = IM_COL32(25, 25, 25, 150);
@@ -2068,6 +2122,7 @@ void StyleColorsClassic()
     GImNodes->Style.Colors[ImNodesCol_BoxSelectorOutline] = IM_COL32(82, 82, 161, 255);
     GImNodes->Style.Colors[ImNodesCol_GridBackground] = IM_COL32(40, 40, 50, 200);
     GImNodes->Style.Colors[ImNodesCol_GridLine] = IM_COL32(200, 200, 200, 40);
+    GImNodes->Style.Colors[ImNodesCol_GridLinePrimary] = IM_COL32(240, 240, 240, 60);
 
     // minimap colors
     GImNodes->Style.Colors[ImNodesCol_MiniMapBackground] = IM_COL32(25, 25, 25, 100);
@@ -2107,6 +2162,7 @@ void StyleColorsLight()
     GImNodes->Style.Colors[ImNodesCol_BoxSelectorOutline] = IM_COL32(90, 170, 250, 150);
     GImNodes->Style.Colors[ImNodesCol_GridBackground] = IM_COL32(225, 225, 225, 255);
     GImNodes->Style.Colors[ImNodesCol_GridLine] = IM_COL32(180, 180, 180, 100);
+    GImNodes->Style.Colors[ImNodesCol_GridLinePrimary] = IM_COL32(120, 120, 120, 100);
 
     // minimap colors
     GImNodes->Style.Colors[ImNodesCol_MiniMapBackground] = IM_COL32(25, 25, 25, 100);
@@ -2153,16 +2209,19 @@ void BeginNodeEditor()
     GImNodes->MousePos = ImGui::GetIO().MousePos;
     GImNodes->LeftMouseClicked = ImGui::IsMouseClicked(0);
     GImNodes->LeftMouseReleased = ImGui::IsMouseReleased(0);
+    GImNodes->LeftMouseDragging = ImGui::IsMouseDragging(0, 0.0f);
     GImNodes->AltMouseClicked =
         (GImNodes->Io.EmulateThreeButtonMouse.Modifier != NULL &&
          *GImNodes->Io.EmulateThreeButtonMouse.Modifier && GImNodes->LeftMouseClicked) ||
         ImGui::IsMouseClicked(GImNodes->Io.AltMouseButton);
-    GImNodes->LeftMouseDragging = ImGui::IsMouseDragging(0, 0.0f);
     GImNodes->AltMouseDragging =
         (GImNodes->Io.EmulateThreeButtonMouse.Modifier != NULL && GImNodes->LeftMouseDragging &&
          (*GImNodes->Io.EmulateThreeButtonMouse.Modifier)) ||
         ImGui::IsMouseDragging(GImNodes->Io.AltMouseButton, 0.0f);
     GImNodes->AltMouseScrollDelta = ImGui::GetIO().MouseWheel;
+    GImNodes->MultipleSelectModifier =
+        (GImNodes->Io.MultipleSelectModifier.Modifier != NULL ?
+         *GImNodes->Io.MultipleSelectModifier.Modifier : ImGui::GetIO().KeyCtrl);
 
     GImNodes->ActiveAttribute = false;
 
@@ -2711,6 +2770,13 @@ ImVec2 GetNodeGridSpacePos(const int node_id)
     return node.Origin;
 }
 
+void SnapNodeToGrid(int node_id)
+{
+    ImNodesEditorContext& editor = EditorContextGet();
+    ImNodeData&           node = ObjectPoolFindOrCreateObject(editor.Nodes, node_id);
+    node.Origin = SnapOriginToGrid(node.Origin);
+}
+
 bool IsEditorHovered() { return MouseInCanvas(); }
 
 bool IsNodeHovered(int* const node_id)
@@ -3029,7 +3095,7 @@ void NodeLineHandler(ImNodesEditorContext& editor, const char* const line)
     else if (sscanf(line, "origin=%i,%i", &x, &y) == 2)
     {
         ImNodeData& node = editor.Nodes.Pool[GImNodes->CurrentNodeIdx];
-        node.Origin = ImVec2((float)x, (float)y);
+        node.Origin = SnapOriginToGrid(ImVec2((float)x, (float)y));
     }
 }
 

--- a/imnodes.h
+++ b/imnodes.h
@@ -36,6 +36,7 @@ enum ImNodesCol_
     ImNodesCol_BoxSelectorOutline,
     ImNodesCol_GridBackground,
     ImNodesCol_GridLine,
+    ImNodesCol_GridLinePrimary,
     ImNodesCol_MiniMapBackground,
     ImNodesCol_MiniMapBackgroundHovered,
     ImNodesCol_MiniMapOutline,
@@ -75,7 +76,9 @@ enum ImNodesStyleFlags_
 {
     ImNodesStyleFlags_None = 0,
     ImNodesStyleFlags_NodeOutline = 1 << 0,
-    ImNodesStyleFlags_GridLines = 1 << 2
+    ImNodesStyleFlags_GridLines = 1 << 2,
+    ImNodesStyleFlags_GridLinesPrimary = 1 << 3,
+    ImNodesStyleFlags_GridSnapping = 1 << 4
 };
 
 enum ImNodesPinShape_
@@ -133,6 +136,21 @@ struct ImNodesIO
         // IsLinkDestroyed() after EndNodeEditor().
         const bool* Modifier;
     } LinkDetachWithModifierClick;
+
+    struct MultipleSelectModifier
+    {
+        MultipleSelectModifier();
+
+        // Pointer to a boolean value indicating when the desired modifier is pressed. Set to NULL
+        // by default. To enable the feature, set the modifier to point to a boolean indicating the
+        // state of a modifier. For example,
+        //
+        // ImNodes::GetIO().MultipleSelectModifier.Modifier = &ImGui::GetIO().KeyCtrl;
+        //
+        // Left-clicking a node with this modifier pressed will add the node to the list of currently
+        // selected nodes. If this value is NULL, the Ctrl key will be used.
+        const bool* Modifier;
+    } MultipleSelectModifier;
 
     // Holding alt mouse button pans the node area, by default middle mouse button will be used
     // Set based on ImGuiMouseButton values
@@ -327,6 +345,9 @@ void SetNodeGridSpacePos(int node_id, const ImVec2& grid_pos);
 ImVec2 GetNodeScreenSpacePos(const int node_id);
 ImVec2 GetNodeEditorSpacePos(const int node_id);
 ImVec2 GetNodeGridSpacePos(const int node_id);
+
+// If ImNodesStyleFlags_GridSnapping is enabled, snap the specified node's origin to the grid.
+void SnapNodeToGrid(int node_id);
 
 // Returns true if the current node editor canvas is being hovered over by the mouse, and is not
 // blocked by any other windows.

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -153,7 +153,7 @@ struct ImNodeData
     bool          Draggable;
 
     ImNodeData(const int node_id)
-        : Id(node_id), Origin(100.0f, 100.0f), TitleBarContentRect(),
+        : Id(node_id), Origin(0.0f, 0.0f), TitleBarContentRect(),
           Rect(ImVec2(0.0f, 0.0f), ImVec2(0.0f, 0.0f)), ColorStyle(), LayoutStyle(), PinIndices(),
           Draggable(true)
     {
@@ -262,6 +262,11 @@ struct ImNodesEditorContext
     ImVector<int> SelectedNodeIndices;
     ImVector<int> SelectedLinkIndices;
 
+    // Relative origins of selected nodes for snapping of dragged nodes
+    ImVector<ImVec2> SelectedNodeOffsets;
+    // Offset of the primary node origin relative to the mouse cursor.
+    ImVec2           PrimaryNodeOffset;
+
     ImClickInteractionState ClickInteraction;
 
     // Mini-map state set by MiniMap()
@@ -280,7 +285,8 @@ struct ImNodesEditorContext
 
     ImNodesEditorContext()
         : Nodes(), Pins(), Links(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),
-          ClickInteraction(), MiniMapEnabled(false), MiniMapSizeFraction(0.0f),
+          SelectedNodeOffsets(), PrimaryNodeOffset(0.f, 0.f), ClickInteraction(),
+          MiniMapEnabled(false), MiniMapSizeFraction(0.0f),
           MiniMapNodeHoveringCallback(NULL), MiniMapNodeHoveringCallbackUserData(NULL),
           MiniMapScaling(0.0f)
     {
@@ -346,6 +352,7 @@ struct ImNodesContext
     bool  LeftMouseDragging;
     bool  AltMouseDragging;
     float AltMouseScrollDelta;
+    bool  MultipleSelectModifier;
 };
 
 namespace IMNODES_NAMESPACE


### PR DESCRIPTION
Updated version of #72 since I apparently cannot push to that PR anymore. Oh well, I needed the motivation to get this going! :smile: Closes #98.

This PR implements snap-to-grid behavior while dragging nodes. Grid snapping uses a simple nearest-point algorithm that works for negative coordinates. Since the last pull request, I made it fancier, so it now snaps the node you started dragging while you're dragging. It's off by default, and totally configurable based on the grid square width and the style flags.

Primary line drawing is very simple, just colors the origin lines a lighter (or darker) shade. Could likely be extended to draw every `n` lines instead, but that's outside of the scope of this PR. It's off by default but controllable with style flags and colors for those who like the UE4 grid drawing and aligning their nodes with the graph origin.

Ctrl-select is another simple feature; when holding down the Ctrl key (configurable to use a different modifier), left clicking on an unselected node will add it to the current selection instead of clearing the selection. Left-clicking a selected node will remove it from the current selection.

Nodes now get created at `(0,0)` instead of `(100,100)` to guarantee they start aligned to the grid - the viewport pan is modified to produce almost-identical behavior to that of before this change. I've also reduced the grid size to default at 24 instead of 32; the snap increment was simply too large at 32 pixels.