### PR TITLE
f/selection improvements

### DIFF
--- a/imnodes.h
+++ b/imnodes.h
@@ -323,12 +323,12 @@ void GetSelectedLinks(int* link_ids);
 // Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
 void ClearNodeSelection();
 void ClearLinkSelection();
-// Use the following two function to add or remove nodes or links from the current editors
-// selection. Note that all functions require the id to be an existing valid id for
-// this editor. Select-functions require the object to currently be selected.
-// Clear-functions require the object to be currently selected.
-// Preconditions listed above can be checked via IsNodeSelected/IsLinkSelected if not tracked
-// by the client code.
+// Use the following functions to add or remove individual nodes or links from the current editors
+// selection. Note that all functions require the id to be an existing valid id for this editor. 
+// Select-functions has the precondition that the object is currently considered unselected.
+// Clear-functions has the precondition that the object is currently considered selected.
+// Preconditions listed above can be checked via IsNodeSelected/IsLinkSelected if not already
+// known.
 void SelectNode(int node_id);
 void ClearNodeSelection(int node_id);
 bool IsNodeSelected(int node_id);

--- a/imnodes.h
+++ b/imnodes.h
@@ -320,10 +320,21 @@ int NumSelectedLinks();
 // returned.
 void GetSelectedNodes(int* node_ids);
 void GetSelectedLinks(int* link_ids);
-
 // Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
 void ClearNodeSelection();
 void ClearLinkSelection();
+// Use the following two function to add or remove nodes or links from the current editors 
+// selection. Note that all functions require the id to be an existing valid id for
+// the current editor. Select functions require the object to currently be deselected.
+// Unselect functions require the object to be currently selected.
+// Preconditions listed above can be checked via IsNodeSelected/IsLinkSelected if not tracked
+// by the client code.
+void SelectNode(int node_id);
+void SelectLink(int link_id);
+void UnselectNode(int node_id);
+void UnselectLink(int link_id);
+bool IsNodeSelected(int node_id);
+bool IsLinkSelected(int link_id);
 
 // Was the previous attribute active? This will continuously return true while the left mouse button
 // is being pressed over the UI content of the attribute.

--- a/imnodes.h
+++ b/imnodes.h
@@ -323,17 +323,17 @@ void GetSelectedLinks(int* link_ids);
 // Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
 void ClearNodeSelection();
 void ClearLinkSelection();
-// Use the following two function to add or remove nodes or links from the current editors 
+// Use the following two function to add or remove nodes or links from the current editors
 // selection. Note that all functions require the id to be an existing valid id for
-// the current editor. Select functions require the object to currently be deselected.
-// Unselect functions require the object to be currently selected.
+// this editor. Select-functions require the object to currently be selected.
+// Clear-functions require the object to be currently selected.
 // Preconditions listed above can be checked via IsNodeSelected/IsLinkSelected if not tracked
 // by the client code.
 void SelectNode(int node_id);
-void SelectLink(int link_id);
-void UnselectNode(int node_id);
-void UnselectLink(int link_id);
+void ClearNodeSelection(int node_id);
 bool IsNodeSelected(int node_id);
+void SelectLink(int link_id);
+void ClearLinkSelection(int link_id);
 bool IsLinkSelected(int link_id);
 
 // Was the previous attribute active? This will continuously return true while the left mouse button

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -480,4 +480,31 @@ static inline T& ObjectPoolFindOrCreateObject(ImObjectPool<T>& objects, const in
     const int index = ObjectPoolFindOrCreateIndex(objects, id);
     return objects.Pool[index];
 }
+
+// Selection helpers
+template<typename T>
+void select_object(const ObjectPool<T>& objects, ImVector<int>& selected_indices, const int id)
+{
+    const int idx = object_pool_find(objects, id);
+    assert(idx >= 0); // id not found, did you pass a valid id?
+    assert(selected_indices.find(idx) == selected_indices.end()); // not previously unselected
+    selected_indices.push_back(idx);
+}
+
+template<typename T>
+void unselect_object(const ObjectPool<T>& objects, ImVector<int>& selected_indices, const int id)
+{
+    const int idx = object_pool_find(objects, id);
+    assert(idx >= 0); // id not found, did you pass a valid id?
+    assert(selected_indices.find(idx) != selected_indices.end()); // not previously selected
+    selected_indices.find_erase_unsorted(idx);
+}
+
+template<typename T>
+bool is_selected(const ObjectPool<T>& objects, ImVector<int>& selected_indices, const int id) 
+{   // note: selected_indices should be const but ImVector is not being const-correct
+    const int idx = object_pool_find(objects, id);
+    return selected_indices.find(idx) != selected_indices.end();
+}
+
 } // namespace ImNodes

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -346,7 +346,7 @@ static inline ImNodesEditorContext& EditorContextGet()
 // [SECTION] ObjectPool implementation
 
 template<typename T>
-static inline int ObjectPoolFind(ImObjectPool<T>& objects, const int id)
+static inline int ObjectPoolFind(const ImObjectPool<T>& objects, const int id)
 {
     const int index = objects.IdMap.GetInt(static_cast<ImGuiID>(id), -1);
     return index;
@@ -480,31 +480,4 @@ static inline T& ObjectPoolFindOrCreateObject(ImObjectPool<T>& objects, const in
     const int index = ObjectPoolFindOrCreateIndex(objects, id);
     return objects.Pool[index];
 }
-
-// Selection helpers
-template<typename T>
-void select_object(const ObjectPool<T>& objects, ImVector<int>& selected_indices, const int id)
-{
-    const int idx = object_pool_find(objects, id);
-    assert(idx >= 0); // id not found, did you pass a valid id?
-    assert(selected_indices.find(idx) == selected_indices.end()); // not previously unselected
-    selected_indices.push_back(idx);
-}
-
-template<typename T>
-void unselect_object(const ObjectPool<T>& objects, ImVector<int>& selected_indices, const int id)
-{
-    const int idx = object_pool_find(objects, id);
-    assert(idx >= 0); // id not found, did you pass a valid id?
-    assert(selected_indices.find(idx) != selected_indices.end()); // not previously selected
-    selected_indices.find_erase_unsorted(idx);
-}
-
-template<typename T>
-bool is_selected(const ObjectPool<T>& objects, ImVector<int>& selected_indices, const int id) 
-{   // note: selected_indices should be const but ImVector is not being const-correct
-    const int idx = object_pool_find(objects, id);
-    return selected_indices.find(idx) != selected_indices.end();
-}
-
 } // namespace ImNodes


### PR DESCRIPTION
Primarily additions to management of selections in resemblence with proposal in https://github.com/Nelarius/imnodes/issues/106:
- Added API to programatically select nodes and links.
- Added API to programatically clear selection of specified node/link.
- Added API to check whether a node or link with specific id is currently selected.
- Fixed implicit conversions between float-double by using float-specific math functions instead of double functions when origin is float type. This eliminates warnings on higher warning levels and eliminates casts/truncation. (bonus)
- Casting result of sscanf to void to avoid warnings on higher warning levels. This also signals that code is not checking for errors.