### PR TITLE
Add auto-panning when mouse goes outside the editor while dragging stuff

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -2295,9 +2295,9 @@ void EndNodeEditor()
             editor.ClickInteraction.Type == ImNodesClickInteractionType_Node;
         if (shouldAutoPan && !MouseInCanvas())
         {
-            auto mouse = ImGui::GetMousePos();
-            auto center = GImNodes->CanvasRectScreenSpace.GetCenter();
-            auto direction = (center - mouse);
+            ImVec2 mouse = ImGui::GetMousePos();
+            ImVec2 center = GImNodes->CanvasRectScreenSpace.GetCenter();
+            ImVec2 direction = (center - mouse);
             direction = direction * ImInvLength(direction, 0.0);
 
             editor.AutoPanningDelta = direction * ImGui::GetIO().DeltaTime * GImNodes->Io.AutoPanningSpeed;

--- a/imnodes.h
+++ b/imnodes.h
@@ -125,6 +125,9 @@ struct ImNodesIO
     // Set based on ImGuiMouseButton values
     int AltMouseButton;
 
+    // Panning speed when dragging an element and mouse is outside the main editor view.
+    float AutoPanningSpeed;
+
     ImNodesIO();
 };
 

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -215,7 +215,7 @@ struct ImClickInteractionState
 
     struct
     {
-        ImRect Rect;
+        ImRect Rect; // Coordinates in grid space
     } BoxSelector;
 
     ImClickInteractionState() : Type(ImNodesClickInteractionType_None) {}
@@ -252,6 +252,7 @@ struct ImNodesEditorContext
 
     // ui related fields
     ImVec2 Panning;
+    ImVec2 AutoPanningDelta;
 
     ImVector<int> SelectedNodeIndices;
     ImVector<int> SelectedLinkIndices;


### PR DESCRIPTION
This adds an auto-panning feature, that automatically pans editor view when mouse goes outside the visible editor view bounds while: dragging nodes; making a box selection; or creating links between nodes.