### PR TITLE
Change mini-map behavior to work as described in issue #117

### DIFF
--- a/example/color_node_editor.cpp
+++ b/example/color_node_editor.cpp
@@ -123,15 +123,68 @@ ImU32 evaluate(const Graph<Node>& graph, const int root_node)
 class ColorNodeEditor
 {
 public:
-    ColorNodeEditor() : graph_(), nodes_(), root_node_id_(-1) {}
+    ColorNodeEditor() : graph_(), nodes_(), root_node_id_(-1),
+        minimap_location_(ImNodesMiniMapLocation_BottomRight) {}
 
     void show()
     {
         // Update timer context
         current_time_seconds = 0.001f * SDL_GetTicks();
 
+        auto flags = ImGuiWindowFlags_MenuBar;
+
         // The node editor window
-        ImGui::Begin("color node editor");
+        ImGui::Begin("color node editor", NULL, flags);
+
+        if (ImGui::BeginMenuBar())
+        {
+            if (ImGui::BeginMenu("Mini-map"))
+            {
+                const char* names[] = {
+                    "Top Left",
+                    "Top Right",
+                    "Bottom Left",
+                    "Bottom Right",
+                };
+                int locations[] = {
+                    ImNodesMiniMapLocation_TopLeft,
+                    ImNodesMiniMapLocation_TopRight,
+                    ImNodesMiniMapLocation_BottomLeft,
+                    ImNodesMiniMapLocation_BottomRight,
+                };
+
+                for (int i = 0; i < 4; i++)
+                {
+                    bool selected = minimap_location_ == locations[i];
+                    if (ImGui::MenuItem(names[i], NULL, &selected))
+                        minimap_location_ = locations[i];
+                }
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::BeginMenu("Style"))
+            {
+                if (ImGui::MenuItem("Classic"))
+                {
+                    ImGui::StyleColorsClassic();
+                    ImNodes::StyleColorsClassic();
+                }
+                if (ImGui::MenuItem("Dark"))
+                {
+                    ImGui::StyleColorsDark();
+                    ImNodes::StyleColorsDark();
+                }
+                if (ImGui::MenuItem("Light"))
+                {
+                    ImGui::StyleColorsLight();
+                    ImNodes::StyleColorsLight();
+                }
+                ImGui::EndMenu();
+            }
+
+            ImGui::EndMenuBar();
+        }
+
         ImGui::TextUnformatted("Edit the color of the output color window using nodes.");
         ImGui::Columns(2);
         ImGui::TextUnformatted("A -- add node");
@@ -489,6 +542,7 @@ public:
             ImNodes::Link(edge.id, edge.from, edge.to);
         }
 
+        ImNodes::MiniMap(0.2f, minimap_location_);
         ImNodes::EndNodeEditor();
 
         // Handle new links
@@ -635,9 +689,10 @@ private:
         };
     };
 
-    Graph<Node>         graph_;
-    std::vector<UiNode> nodes_;
-    int                 root_node_id_;
+    Graph<Node>            graph_;
+    std::vector<UiNode>    nodes_;
+    int                    root_node_id_;
+    ImNodesMiniMapLocation minimap_location_;
 };
 
 static ColorNodeEditor color_editor;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -2590,7 +2590,6 @@ void PushStyleVar(const ImNodesStyleVar item, const float value)
     const ImNodesStyleVarInfo* var_info = GetStyleVarInfo(item);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 1)
     {
-        ImGuiContext& g = *GImGui;
         float& style_var = *(float*)var_info->GetVarPtr(&GImNodes->Style);
         GImNodes->StyleModifierStack.push_back(ImNodesStyleVarElement(item, style_var));
         style_var = value;
@@ -2604,7 +2603,6 @@ void PushStyleVar(const ImNodesStyleVar item, const ImVec2& value)
     const ImNodesStyleVarInfo* var_info = GetStyleVarInfo(item);
     if (var_info->Type == ImGuiDataType_Float && var_info->Count == 2)
     {
-        ImGuiContext& g = *GImGui;
         ImVec2& style_var = *(ImVec2*)var_info->GetVarPtr(&GImNodes->Style);
         GImNodes->StyleModifierStack.push_back(ImNodesStyleVarElement(item, style_var));
         style_var = value;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1846,7 +1846,7 @@ static void MiniMapUpdate()
         mini_map_is_hovered &&
         ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
         editor.ClickInteraction.Type == ImNodesClickInteractionType_None &&
-        !editor.Nodes.Pool.empty();
+        !GImNodes->NodeIdxSubmissionOrder.empty();
     if (center_on_click)
     {
         ImVec2 target = MiniMapSpaceToGridSpace(editor, ImGui::GetMousePos());

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1805,9 +1805,10 @@ static void MiniMapUpdate()
     ImGui::InvisibleButton("minimap", editor.MiniMapRectScreenSpace.GetSize());
 
     bool center_on_click =
+        ImGui::IsMouseDown(ImGuiMouseButton_Left) &&
         editor.ClickInteraction.Type == ImNodesClickInteractionType_None &&
         ImGui::IsItemActive() &&
-        ImGui::IsMouseDown(ImGuiMouseButton_Left);
+        !editor.Nodes.Pool.empty();
     if (center_on_click)
     {
         editor.ClickInteraction.Type = ImNodesClickInteractionType_CenterOnRequest;

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1905,8 +1905,8 @@ ImNodesIO::ImNodesIO()
 }
 
 ImNodesStyle::ImNodesStyle()
-    : GridSpacing(32.f), NodeCornerRounding(4.f), NodePaddingHorizontal(8.f),
-      NodePaddingVertical(8.f), NodeBorderThickness(1.f), LinkThickness(3.f),
+    : GridSpacing(32.f), NodeCornerRounding(4.f), NodePadding(8.f, 8.f),
+      NodeBorderThickness(1.f), LinkThickness(3.f),
       LinkLineSegmentsPerLength(0.1f), LinkHoverDistance(10.f), PinCircleRadius(4.f),
       PinQuadSideLength(7.f), PinTriangleSideLength(9.5), PinLineThickness(1.f),
       PinHoverRadius(10.f), PinOffset(0.f),
@@ -2368,8 +2368,7 @@ void BeginNode(const int node_id)
     node.ColorStyle.TitlebarHovered = GImNodes->Style.Colors[ImNodesCol_TitleBarHovered];
     node.ColorStyle.TitlebarSelected = GImNodes->Style.Colors[ImNodesCol_TitleBarSelected];
     node.LayoutStyle.CornerRounding = GImNodes->Style.NodeCornerRounding;
-    node.LayoutStyle.Padding =
-        ImVec2(GImNodes->Style.NodePaddingHorizontal, GImNodes->Style.NodePaddingVertical);
+    node.LayoutStyle.Padding = GImNodes->Style.NodePadding;
     node.LayoutStyle.BorderThickness = GImNodes->Style.NodeBorderThickness;
 
     // ImGui::SetCursorPos sets the cursor position, local to the current widget
@@ -2548,10 +2547,8 @@ static const ImNodesStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, GridSpacing) },
     // ImNodesStyleVar_NodeCornerRounding
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeCornerRounding) },
-    // ImNodesStyleVar_NodePaddingHorizontal
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePaddingHorizontal) },
-    // ImNodesStyleVar_NodePaddingVertical
-    { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePaddingVertical) },
+    // ImNodesStyleVar_NodePadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, NodePadding) },
     // ImNodesStyleVar_NodeBorderThickness
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, NodeBorderThickness) },
     // ImNodesStyleVar_LinkThickness

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -2564,6 +2564,10 @@ static const ImNodesStyleVarInfo GStyleVarInfo[] =
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinHoverRadius) },
     // ImNodesStyleVar_PinOffset
     { ImGuiDataType_Float, 1, (ImU32)IM_OFFSETOF(ImNodesStyle, PinOffset) },
+    // ImNodesStyleVar_MiniMapPadding
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapPadding) },
+    // ImNodesStyleVar_MiniMapOffset
+    { ImGuiDataType_Float, 2, (ImU32)IM_OFFSETOF(ImNodesStyle, MiniMapOffset) },
 };
 
 static const ImNodesStyleVarInfo* GetStyleVarInfo(ImNodesStyleVar idx)

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -258,6 +258,11 @@ inline ImVec2 ScreenSpaceToGridSpace(const ImNodesEditorContext& editor, const I
     return v - GImNodes->CanvasOriginScreenSpace - editor.Panning;
 }
 
+inline ImRect ScreenSpaceToGridSpace(const ImNodesEditorContext& editor, const ImRect& r)
+{
+    return ImRect(ScreenSpaceToGridSpace(editor, r.Min), ScreenSpaceToGridSpace(editor, r.Max));
+}
+
 inline ImVec2 GridSpaceToScreenSpace(const ImNodesEditorContext& editor, const ImVec2& v)
 {
     return v + GImNodes->CanvasOriginScreenSpace + editor.Panning;
@@ -2176,6 +2181,12 @@ void EndNodeEditor()
     GImNodes->CurrentScope = ImNodesScope_None;
 
     ImNodesEditorContext& editor = EditorContextGet();
+
+    bool no_grid_content = editor.GridContentBounds.IsInverted();
+    if (no_grid_content)
+    {
+        editor.GridContentBounds = ScreenSpaceToGridSpace(editor, GImNodes->CanvasRectScreenSpace);
+    }
 
     // Detect ImGui interaction first, because it blocks interaction with the rest of the UI
 

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1655,10 +1655,12 @@ static inline void CalcMiniMapLayout()
     ImVec2 mini_map_size;
     float mini_map_scaling;
     {
-        const ImVec2 grid_content_size = ImFloor(editor.GridContentBounds.GetSize());
-        const float  grid_content_aspect_ratio = grid_content_size.x / grid_content_size.y;
         const ImVec2 max_size = ImFloor(editor_rect.GetSize() * editor.MiniMapSizeFraction - border * 2.0f);
         const float  max_size_aspect_ratio = max_size.x / max_size.y;
+        const ImVec2 grid_content_size = editor.GridContentBounds.IsInverted()
+            ? max_size
+            : ImFloor(editor.GridContentBounds.GetSize());
+        const float  grid_content_aspect_ratio = grid_content_size.x / grid_content_size.y;
         mini_map_size = ImFloor(grid_content_aspect_ratio > max_size_aspect_ratio
             ? ImVec2(max_size.x, max_size.x / grid_content_aspect_ratio)
             : ImVec2(max_size.y * grid_content_aspect_ratio, max_size.y));

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1908,7 +1908,7 @@ ImNodesStyle::ImNodesStyle()
       LinkLineSegmentsPerLength(0.1f), LinkHoverDistance(10.f), PinCircleRadius(4.f),
       PinQuadSideLength(7.f), PinTriangleSideLength(9.5), PinLineThickness(1.f),
       PinHoverRadius(10.f), PinOffset(0.f),
-      MiniMapPadding(4.0f, 4.0f), MiniMapOffset(4.0f, 4.0f),
+      MiniMapPadding(8.0f, 8.0f), MiniMapOffset(4.0f, 4.0f),
       Flags(ImNodesStyleFlags_NodeOutline | ImNodesStyleFlags_GridLines), Colors()
 {
 }

--- a/imnodes.h
+++ b/imnodes.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <imgui.h>
 
 #ifndef IMNODES_NAMESPACE
 #define IMNODES_NAMESPACE ImNodes
@@ -41,6 +42,8 @@ enum ImNodesCol_
     ImNodesCol_MiniMapNodeOutline,
     ImNodesCol_MiniMapLink,
     ImNodesCol_MiniMapLinkSelected,
+    ImNodesCol_MiniMapCanvas,
+    ImNodesCol_MiniMapCanvasOutline,
     ImNodesCol_COUNT
 };
 
@@ -167,6 +170,11 @@ struct ImNodesStyle
     float PinHoverRadius;
     // Offsets the pins' positions from the edge of the node to the outside of the node.
     float PinOffset;
+
+    // Mini-map padding size between mini-map edge and mini-map content.
+    ImVec2 MiniMapPadding;
+    // Mini-map offset from the screen side.
+    ImVec2 MiniMapOffset;
 
     // By default, ImNodesStyleFlags_NodeOutline and ImNodesStyleFlags_Gridlines are enabled.
     ImNodesStyleFlags Flags;

--- a/imnodes.h
+++ b/imnodes.h
@@ -63,6 +63,8 @@ enum ImNodesStyleVar_
     ImNodesStyleVar_PinLineThickness,
     ImNodesStyleVar_PinHoverRadius,
     ImNodesStyleVar_PinOffset,
+    ImNodesStyleVar_MiniMapPadding,
+    ImNodesStyleVar_MiniMapOffset,
     ImNodesStyleVar_COUNT
 };
 

--- a/imnodes.h
+++ b/imnodes.h
@@ -62,7 +62,8 @@ enum ImNodesStyleVar_
     ImNodesStyleVar_PinTriangleSideLength,
     ImNodesStyleVar_PinLineThickness,
     ImNodesStyleVar_PinHoverRadius,
-    ImNodesStyleVar_PinOffset
+    ImNodesStyleVar_PinOffset,
+    ImNodesStyleVar_COUNT
 };
 
 enum ImNodesStyleFlags_
@@ -252,7 +253,8 @@ void MiniMap(
 void PushColorStyle(ImNodesCol item, unsigned int color);
 void PopColorStyle();
 void PushStyleVar(ImNodesStyleVar style_item, float value);
-void PopStyleVar();
+void PushStyleVar(ImNodesStyleVar style_item, const ImVec2& value);
+void PopStyleVar(int count = 1);
 
 // id can be any positive or negative integer, but INT_MIN is currently reserved for internal use.
 void BeginNode(int id);

--- a/imnodes.h
+++ b/imnodes.h
@@ -51,8 +51,7 @@ enum ImNodesStyleVar_
 {
     ImNodesStyleVar_GridSpacing = 0,
     ImNodesStyleVar_NodeCornerRounding,
-    ImNodesStyleVar_NodePaddingHorizontal,
-    ImNodesStyleVar_NodePaddingVertical,
+    ImNodesStyleVar_NodePadding,
     ImNodesStyleVar_NodeBorderThickness,
     ImNodesStyleVar_LinkThickness,
     ImNodesStyleVar_LinkLineSegmentsPerLength,
@@ -146,8 +145,7 @@ struct ImNodesStyle
     float GridSpacing;
 
     float NodeCornerRounding;
-    float NodePaddingHorizontal;
-    float NodePaddingVertical;
+    ImVec2 NodePadding;
     float NodeBorderThickness;
 
     float LinkThickness;

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -58,9 +58,7 @@ enum ImNodesClickInteractionType_
     ImNodesClickInteractionType_LinkCreation,
     ImNodesClickInteractionType_Panning,
     ImNodesClickInteractionType_BoxSelection,
-    ImNodesClickInteractionType_MiniMapPanning,
-    ImNodesClickInteractionType_MiniMapZooming,
-    ImNodesClickInteractionType_MiniMapSnapping,
+    ImNodesClickInteractionType_CenterOnRequest,
     ImNodesClickInteractionType_ImGuiItem,
     ImNodesClickInteractionType_None
 };
@@ -252,15 +250,38 @@ struct ImNodesEditorContext
     // ui related fields
     ImVec2 Panning;
     ImVec2 AutoPanningDelta;
+    // Minimum and maximum extents of all content in grid space. Valid after final
+    // ImNodes::EndNode() call.
+    ImRect GridContentBounds;
+
+    // When ImNodesClickInteractionType_CenterOnRequest is set, indicates location in grid space to
+    // center on.
+    ImVec2 CenterOnRequest;
 
     ImVector<int> SelectedNodeIndices;
     ImVector<int> SelectedLinkIndices;
 
     ImClickInteractionState ClickInteraction;
 
+    // Mini-map state set by MiniMap()
+
+    bool                               MiniMapEnabled;
+    ImNodesMiniMapLocation             MiniMapLocation;
+    float                              MiniMapSizeFraction;
+    ImNodesMiniMapNodeHoveringCallback MiniMapNodeHoveringCallback;
+    void*                              MiniMapNodeHoveringCallbackUserData;
+
+    // Mini-map state set during EndNodeEditor() call
+
+    ImRect                             MiniMapRectScreenSpace;
+    ImRect                             MiniMapContentScreenSpace;
+    float                              MiniMapScaling;
+
     ImNodesEditorContext()
         : Nodes(), Pins(), Links(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),
-          ClickInteraction()
+          ClickInteraction(), MiniMapEnabled(false), MiniMapSizeFraction(0.0f),
+          MiniMapNodeHoveringCallback(NULL), MiniMapNodeHoveringCallbackUserData(NULL),
+          MiniMapScaling(0.0f)
     {
     }
 };
@@ -280,13 +301,6 @@ struct ImNodesContext
     // Canvas extents
     ImVec2 CanvasOriginScreenSpace;
     ImRect CanvasRectScreenSpace;
-
-    // MiniMap state
-    ImRect                             MiniMapRectScreenSpace;
-    ImVec2                             MiniMapRectSnappingOffset;
-    float                              MiniMapZoom;
-    ImNodesMiniMapNodeHoveringCallback MiniMapNodeHoveringCallback;
-    void*                              MiniMapNodeHoveringCallbackUserData;
 
     // Debug helpers
     ImNodesScope CurrentScope;

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -229,11 +229,19 @@ struct ImNodesColElement
 struct ImNodesStyleVarElement
 {
     ImNodesStyleVar Item;
-    float           Value;
+    float           FloatValue[2];
 
-    ImNodesStyleVarElement(const float value, const ImNodesStyleVar variable)
-        : Item(variable), Value(value)
+    ImNodesStyleVarElement(const ImNodesStyleVar variable, const float value)
+        : Item(variable)
     {
+        FloatValue[0] = value;
+    }
+
+    ImNodesStyleVarElement(const ImNodesStyleVar variable, const ImVec2 value)
+        : Item(variable)
+    {
+        FloatValue[0] = value.x;
+        FloatValue[1] = value.y;
     }
 };
 

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -58,7 +58,6 @@ enum ImNodesClickInteractionType_
     ImNodesClickInteractionType_LinkCreation,
     ImNodesClickInteractionType_Panning,
     ImNodesClickInteractionType_BoxSelection,
-    ImNodesClickInteractionType_CenterOnRequest,
     ImNodesClickInteractionType_ImGuiItem,
     ImNodesClickInteractionType_None
 };
@@ -261,10 +260,6 @@ struct ImNodesEditorContext
     // Minimum and maximum extents of all content in grid space. Valid after final
     // ImNodes::EndNode() call.
     ImRect GridContentBounds;
-
-    // When ImNodesClickInteractionType_CenterOnRequest is set, indicates location in grid space to
-    // center on.
-    ImVec2 CenterOnRequest;
 
     ImVector<int> SelectedNodeIndices;
     ImVector<int> SelectedLinkIndices;


### PR DESCRIPTION
Change mini-map behavior to work as described in issue #117

Mini-map changes:

* Remove old panning/zooming behavior
* Fit and show full node graph
* Show editor's canvas rect
* On click/drag center editor's canvas to selected location

Color node editor example changes:

* Add menu to change mini-map location
* Add menu to change style

Internal changes:

* Refactor how style variables are backed up to follow ImGui style

NOTE: This is based on top of PR #120, so probably that one should go in first.