### PR TITLE
Fix selection issues with pins overlapping unrelated links. Fix not being able to start new links when there is an existing link on a pin

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -571,46 +571,6 @@ void BeginLinkDetach(ImNodesEditorContext& editor, const int link_idx, const int
     GImNodes->DeletedLinkIdx = link_idx;
 }
 
-void BeginLinkInteraction(ImNodesEditorContext& editor, const int link_idx)
-{
-    // Check the 'click and drag to detach' case.
-    if (GImNodes->HoveredPinIdx.HasValue() &&
-        (editor.Pins.Pool[GImNodes->HoveredPinIdx.Value()].Flags &
-         ImNodesAttributeFlags_EnableLinkDetachWithDragClick) != 0)
-    {
-        BeginLinkDetach(editor, link_idx, GImNodes->HoveredPinIdx.Value());
-        editor.ClickInteraction.LinkCreation.Type = ImNodesLinkCreationType_FromDetach;
-    }
-    // If we aren't near a pin, check if we are clicking the link with the
-    // modifier pressed. This may also result in a link detach via clicking.
-    else
-    {
-        const bool modifier_pressed = GImNodes->Io.LinkDetachWithModifierClick.Modifier == NULL
-                                          ? false
-                                          : *GImNodes->Io.LinkDetachWithModifierClick.Modifier;
-
-        if (modifier_pressed)
-        {
-            const ImLinkData& link = editor.Links.Pool[link_idx];
-            const ImPinData&  start_pin = editor.Pins.Pool[link.StartPinIdx];
-            const ImPinData&  end_pin = editor.Pins.Pool[link.EndPinIdx];
-            const ImVec2&     mouse_pos = GImNodes->MousePos;
-            const float       dist_to_start = ImLengthSqr(start_pin.Pos - mouse_pos);
-            const float       dist_to_end = ImLengthSqr(end_pin.Pos - mouse_pos);
-            const int         closest_pin_idx =
-                dist_to_start < dist_to_end ? link.StartPinIdx : link.EndPinIdx;
-
-            editor.ClickInteraction.Type = ImNodesClickInteractionType_LinkCreation;
-            BeginLinkDetach(editor, link_idx, closest_pin_idx);
-            editor.ClickInteraction.LinkCreation.Type = ImNodesLinkCreationType_FromDetach;
-        }
-        else
-        {
-            BeginLinkSelection(editor, link_idx);
-        }
-    }
-}
-
 void BeginLinkCreation(ImNodesEditorContext& editor, const int hovered_pin_idx)
 {
     editor.ClickInteraction.Type = ImNodesClickInteractionType_LinkCreation;
@@ -618,6 +578,55 @@ void BeginLinkCreation(ImNodesEditorContext& editor, const int hovered_pin_idx)
     editor.ClickInteraction.LinkCreation.EndPinIdx.Reset();
     editor.ClickInteraction.LinkCreation.Type = ImNodesLinkCreationType_Standard;
     GImNodes->ImNodesUIState |= ImNodesUIState_LinkStarted;
+}
+
+void BeginLinkInteraction(ImNodesEditorContext& editor, const int link_idx,
+    const ImOptionalIndex pin_idx = {})
+{
+    // Check if we are clicking the link with the modifier pressed.
+    // This will in a link detach via clicking.
+    
+    const bool modifier_pressed = GImNodes->Io.LinkDetachWithModifierClick.Modifier == NULL
+                                      ? false
+                                      : *GImNodes->Io.LinkDetachWithModifierClick.Modifier;
+
+    if (modifier_pressed)
+    {
+        const ImLinkData& link = editor.Links.Pool[link_idx];
+        const ImPinData&  start_pin = editor.Pins.Pool[link.StartPinIdx];
+        const ImPinData&  end_pin = editor.Pins.Pool[link.EndPinIdx];
+        const ImVec2&     mouse_pos = GImNodes->MousePos;
+        const float       dist_to_start = ImLengthSqr(start_pin.Pos - mouse_pos);
+        const float       dist_to_end = ImLengthSqr(end_pin.Pos - mouse_pos);
+        const int         closest_pin_idx =
+            dist_to_start < dist_to_end ? link.StartPinIdx : link.EndPinIdx;
+
+        editor.ClickInteraction.Type = ImNodesClickInteractionType_LinkCreation;
+        BeginLinkDetach(editor, link_idx, closest_pin_idx);
+        editor.ClickInteraction.LinkCreation.Type = ImNodesLinkCreationType_FromDetach;        
+    }    
+    else
+    {
+        if (pin_idx.HasValue())
+        {
+            const int hoveredPinFlags = editor.Pins.Pool[pin_idx.Value()].Flags;
+
+            // Check the 'click and drag to detach' case.
+            if (hoveredPinFlags & ImNodesAttributeFlags_EnableLinkDetachWithDragClick)
+            {
+                BeginLinkDetach(editor, link_idx, pin_idx.Value());
+                editor.ClickInteraction.LinkCreation.Type = ImNodesLinkCreationType_FromDetach;
+            }
+            else
+            {
+                BeginLinkCreation(editor, pin_idx.Value());
+            }
+        }
+        else
+        {
+            BeginLinkSelection(editor, link_idx);
+        }
+    }
 }
 
 static inline bool IsMiniMapHovered();
@@ -1184,10 +1193,15 @@ ImOptionalIndex ResolveHoveredLink(
         const ImPinData&  start_pin = pins.Pool[link.StartPinIdx];
         const ImPinData&  end_pin = pins.Pool[link.EndPinIdx];
 
-        if (GImNodes->HoveredPinIdx == link.StartPinIdx ||
-            GImNodes->HoveredPinIdx == link.EndPinIdx)
+        // If there is a hovered pin links can only be considered hovered if they use that pin
+        if (GImNodes->HoveredPinIdx.HasValue())
         {
-            return idx;
+            if (GImNodes->HoveredPinIdx == link.StartPinIdx ||
+                GImNodes->HoveredPinIdx == link.EndPinIdx)
+            {
+                return idx;
+            }
+            continue;
         }
 
         // TODO: the calculated CubicBeziers could be cached since we generate them again when
@@ -2263,7 +2277,8 @@ void EndNodeEditor()
     {
         if (GImNodes->LeftMouseClicked && GImNodes->HoveredLinkIdx.HasValue())
         {
-            BeginLinkInteraction(editor, GImNodes->HoveredLinkIdx.Value());
+            BeginLinkInteraction(editor, GImNodes->HoveredLinkIdx.Value(),
+                GImNodes->HoveredPinIdx);
         }
 
         else if (GImNodes->LeftMouseClicked && GImNodes->HoveredPinIdx.HasValue())

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -581,7 +581,7 @@ void BeginLinkCreation(ImNodesEditorContext& editor, const int hovered_pin_idx)
 }
 
 void BeginLinkInteraction(ImNodesEditorContext& editor, const int link_idx,
-    const ImOptionalIndex pin_idx = {})
+    const ImOptionalIndex pin_idx = ImOptionalIndex())
 {
     // Check if we are clicking the link with the modifier pressed.
     // This will in a link detach via clicking.


### PR DESCRIPTION
Includes changes from https://github.com/Nelarius/imnodes/pull/124

In v0.4 of ImNodes it is possible to start a link on an pin that already has a link. As part of the input handling changes this is no longer possible, attempting to start a new link simply selects the existing link.

If there is a hovered pin a link should only be considered hovered if that link connects to the hovered pin. This avoids issues where if there is a link behind an unrelated hovered pin it would be considered hovered and cause odd interactions.