### PR TITLE
Allow User Defined Callbacks and Custom Header like ImGui #115

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1644,8 +1644,8 @@ void Initialize(ImNodesContext* context)
     context->MiniMapRectScreenSpace = ImRect(ImVec2(0.f, 0.f), ImVec2(0.f, 0.f));
     context->MiniMapRectSnappingOffset = ImVec2(0.f, 0.f);
     context->MiniMapZoom = 0.1f;
-    context->MiniMapNodeHoveringCallback = NULL;
-    context->MiniMapNodeHoveringCallbackUserData = NULL;
+    context->MiniMapNodeHoveringCallback = ImNodesMiniMapNodeHoveringCallbackDefault;
+    context->MiniMapNodeHoveringCallbackUserData = ImNodesMiniMapNodeHoveringCallbackUserDataDefault;
 
     context->CurrentPinIdx = INT_MAX;
     context->CurrentNodeIdx = INT_MAX;
@@ -1885,8 +1885,8 @@ static void MiniMapUpdate()
     GImNodes->CanvasDrawList->PopClipRect();
 
     // Reset callback info after use
-    GImNodes->MiniMapNodeHoveringCallback = NULL;
-    GImNodes->MiniMapNodeHoveringCallbackUserData = NULL;
+    GImNodes->MiniMapNodeHoveringCallback = ImNodesMiniMapNodeHoveringCallbackDefault;
+    GImNodes->MiniMapNodeHoveringCallbackUserData = ImNodesMiniMapNodeHoveringCallbackUserDataDefault;
 
     // Reset mini-map area so that it will disappear if MiniMap(...) is not called on the next frame
     GImNodes->MiniMapRectScreenSpace = ImRect(ImVec2(0.f, 0.f), ImVec2(0.f, 0.f));
@@ -2342,7 +2342,7 @@ void MiniMap(
     const float                              minimap_size_fraction,
     const ImNodesMiniMapLocation             location,
     const ImNodesMiniMapNodeHoveringCallback node_hovering_callback,
-    void*                                    node_hovering_callback_data)
+    const ImNodesMiniMapNodeHoveringCallbackUserData node_hovering_callback_data)
 {
     // Check that editor size fraction is sane; must be in the range (0, 1]
     assert(minimap_size_fraction > 0.f && minimap_size_fraction <= 1.f);

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1644,8 +1644,8 @@ void Initialize(ImNodesContext* context)
     context->MiniMapRectScreenSpace = ImRect(ImVec2(0.f, 0.f), ImVec2(0.f, 0.f));
     context->MiniMapRectSnappingOffset = ImVec2(0.f, 0.f);
     context->MiniMapZoom = 0.1f;
-    context->MiniMapNodeHoveringCallback = ImNodesMiniMapNodeHoveringCallbackDefault;
-    context->MiniMapNodeHoveringCallbackUserData = ImNodesMiniMapNodeHoveringCallbackUserDataDefault;
+    context->MiniMapNodeHoveringCallback = NULL;
+    context->MiniMapNodeHoveringCallbackUserData = NULL;
 
     context->CurrentPinIdx = INT_MAX;
     context->CurrentNodeIdx = INT_MAX;
@@ -1885,8 +1885,8 @@ static void MiniMapUpdate()
     GImNodes->CanvasDrawList->PopClipRect();
 
     // Reset callback info after use
-    GImNodes->MiniMapNodeHoveringCallback = ImNodesMiniMapNodeHoveringCallbackDefault;
-    GImNodes->MiniMapNodeHoveringCallbackUserData = ImNodesMiniMapNodeHoveringCallbackUserDataDefault;
+    GImNodes->MiniMapNodeHoveringCallback = NULL;
+    GImNodes->MiniMapNodeHoveringCallbackUserData = NULL;
 
     // Reset mini-map area so that it will disappear if MiniMap(...) is not called on the next frame
     GImNodes->MiniMapRectScreenSpace = ImRect(ImVec2(0.f, 0.f), ImVec2(0.f, 0.f));

--- a/imnodes.h
+++ b/imnodes.h
@@ -198,7 +198,13 @@ struct ImNodesContext;
 struct ImNodesEditorContext;
 
 // Callback type used to specify special behavior when hovering a node in the minimap
+#ifndef ImNodesMiniMapNodeHoveringCallback
 typedef void (*ImNodesMiniMapNodeHoveringCallback)(int, void*);
+#endif
+
+#ifndef ImNodesMiniMapNodeHoveringCallbackUserData
+typedef void* ImNodesMiniMapNodeHoveringCallbackUserData;
+#endif
 
 namespace IMNODES_NAMESPACE
 {

--- a/imnodes.h
+++ b/imnodes.h
@@ -206,8 +206,16 @@ struct ImNodesEditorContext;
 typedef void (*ImNodesMiniMapNodeHoveringCallback)(int, void*);
 #endif
 
+#ifndef ImNodesMiniMapNodeHoveringCallbackDefault
+#define ImNodesMiniMapNodeHoveringCallbackDefault NULL
+#endif
+
 #ifndef ImNodesMiniMapNodeHoveringCallbackUserData
 typedef void* ImNodesMiniMapNodeHoveringCallbackUserData;
+#endif
+
+#ifndef ImNodesMiniMapNodeHoveringCallbackUserDataDefault
+#define ImNodesMiniMapNodeHoveringCallbackUserDataDefault NULL
 #endif
 
 namespace IMNODES_NAMESPACE
@@ -247,8 +255,8 @@ void EndNodeEditor();
 void MiniMap(
     const float                              minimap_size_fraction = 0.2f,
     const ImNodesMiniMapLocation             location = ImNodesMiniMapLocation_TopLeft,
-    const ImNodesMiniMapNodeHoveringCallback node_hovering_callback = NULL,
-    void*                                    node_hovering_callback_data = NULL);
+    const ImNodesMiniMapNodeHoveringCallback node_hovering_callback = ImNodesMiniMapNodeHoveringCallbackDefault,
+    const ImNodesMiniMapNodeHoveringCallbackUserData node_hovering_callback_data = ImNodesMiniMapNodeHoveringCallbackUserDataDefault);
 
 // Use PushColorStyle and PopColorStyle to modify ImNodesStyle::Colors mid-frame.
 void PushColorStyle(ImNodesCol item, unsigned int color);

--- a/imnodes.h
+++ b/imnodes.h
@@ -206,16 +206,8 @@ struct ImNodesEditorContext;
 typedef void (*ImNodesMiniMapNodeHoveringCallback)(int, void*);
 #endif
 
-#ifndef ImNodesMiniMapNodeHoveringCallbackDefault
-#define ImNodesMiniMapNodeHoveringCallbackDefault NULL
-#endif
-
 #ifndef ImNodesMiniMapNodeHoveringCallbackUserData
 typedef void* ImNodesMiniMapNodeHoveringCallbackUserData;
-#endif
-
-#ifndef ImNodesMiniMapNodeHoveringCallbackUserDataDefault
-#define ImNodesMiniMapNodeHoveringCallbackUserDataDefault NULL
 #endif
 
 namespace IMNODES_NAMESPACE
@@ -255,8 +247,8 @@ void EndNodeEditor();
 void MiniMap(
     const float                              minimap_size_fraction = 0.2f,
     const ImNodesMiniMapLocation             location = ImNodesMiniMapLocation_TopLeft,
-    const ImNodesMiniMapNodeHoveringCallback node_hovering_callback = ImNodesMiniMapNodeHoveringCallbackDefault,
-    const ImNodesMiniMapNodeHoveringCallbackUserData node_hovering_callback_data = ImNodesMiniMapNodeHoveringCallbackUserDataDefault);
+    const ImNodesMiniMapNodeHoveringCallback node_hovering_callback = NULL,
+    const ImNodesMiniMapNodeHoveringCallbackUserData node_hovering_callback_data = NULL);
 
 // Use PushColorStyle and PopColorStyle to modify ImNodesStyle::Colors mid-frame.
 void PushColorStyle(ImNodesCol item, unsigned int color);

--- a/imnodes.h
+++ b/imnodes.h
@@ -2,6 +2,10 @@
 
 #include <stddef.h>
 
+#ifdef IMNODES_USER_CONFIG
+#include IMNODES_USER_CONFIG
+#endif
+
 #ifndef IMNODES_NAMESPACE
 #define IMNODES_NAMESPACE ImNodes
 #endif

--- a/imnodes_config.h
+++ b/imnodes_config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define ImNodesMiniMapNodeHoveringCallback py::function
+
+#define ImNodesMiniMapNodeHoveringCallbackUserData py::object

--- a/imnodes_config.h
+++ b/imnodes_config.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#define ImNodesMiniMapNodeHoveringCallback py::function
-
-#define ImNodesMiniMapNodeHoveringCallbackUserData py::object

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -286,7 +286,7 @@ struct ImNodesContext
     ImVec2                             MiniMapRectSnappingOffset;
     float                              MiniMapZoom;
     ImNodesMiniMapNodeHoveringCallback MiniMapNodeHoveringCallback;
-    void*                              MiniMapNodeHoveringCallbackUserData;
+    ImNodesMiniMapNodeHoveringCallbackUserData MiniMapNodeHoveringCallbackUserData;
 
     // Debug helpers
     ImNodesScope CurrentScope;


### PR DESCRIPTION
Minimally invasive change to allow pybind11 callback and callback data

Here is what it basically looks like in my project if anyone is curious.  I had to extend py::object to be assignable from NULL and also extend the bool conversion operator to test for Py_None.  I slapped it together over the weekend so I'm sure it can be improved.  The upside is not having to make any modifications to ImNodes source except for adding the conditional typedefs/macros.

CMakeLists.txt:
`target_compile_definitions(${THIS} PRIVATE IMNODES_USER_CONFIG=<imnodes_config.h>)`

imnodes_config.h:
```
#pragma once

#include <pybind11/functional.h>

namespace pybind11 {

inline bool PyWrapper_Check(PyObject *o) { return true; }

class wrapper : public object {
public:
    PYBIND11_OBJECT_DEFAULT(wrapper, object, PyWrapper_Check)
    wrapper(void* x) { m_ptr = (PyObject*)x; }
    explicit operator bool() const { return m_ptr != nullptr && m_ptr != Py_None; }
};

} //namespace pybind11

namespace py = pybind11;

#define ImNodesMiniMapNodeHoveringCallback py::wrapper

#define ImNodesMiniMapNodeHoveringCallbackUserData py::wrapper

```