### PR TITLE
added GetOrCreateNodeEditorSpacePos

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -2759,6 +2759,13 @@ ImVec2 GetNodeScreenSpacePos(const int node_id)
     return GridSpaceToScreenSpace(editor, node.Origin);
 }
 
+ImVec2 GetOrCreateNodeEditorSpacePos(const int node_id)
+{
+    ImNodesEditorContext& editor = EditorContextGet();
+    ImNodeData& node = ObjectPoolFindOrCreateObject(editor.Nodes, node_id);
+    return GridSpaceToEditorSpace(editor, node.Origin);
+}
+
 ImVec2 GetNodeEditorSpacePos(const int node_id)
 {
     ImNodesEditorContext& editor = EditorContextGet();

--- a/imnodes.h
+++ b/imnodes.h
@@ -342,6 +342,7 @@ void SetNodeScreenSpacePos(int node_id, const ImVec2& screen_space_pos);
 void SetNodeEditorSpacePos(int node_id, const ImVec2& editor_space_pos);
 void SetNodeGridSpacePos(int node_id, const ImVec2& grid_pos);
 
+ImVec2 GetOrCreateNodeEditorSpacePos(const int node_id);
 ImVec2 GetNodeScreenSpacePos(const int node_id);
 ImVec2 GetNodeEditorSpacePos(const int node_id);
 ImVec2 GetNodeGridSpacePos(const int node_id);


### PR DESCRIPTION
Added GetOrCreateNodeEditorSpacePos that uses ObjectPoolFindOrCreateObject instead of asserting like GetNodeEditorSpacePos
