### PR TITLE
Big link refactor

### DIFF
--- a/example/multi_editor.cpp
+++ b/example/multi_editor.cpp
@@ -117,7 +117,6 @@ void NodeEditorInitialize()
 {
     editor1.context = ImNodes::EditorContextCreate();
     editor2.context = ImNodes::EditorContextCreate();
-    ImNodes::PushAttributeFlag(ImNodesAttributeFlags_EnableLinkDetachWithDragClick);
 
     ImNodesIO& io = ImNodes::GetIO();
     io.LinkDetachWithModifierClick.Modifier = &ImGui::GetIO().KeyCtrl;

--- a/example/save_load.cpp
+++ b/example/save_load.cpp
@@ -192,7 +192,6 @@ static SaveLoadEditor editor;
 void NodeEditorInitialize()
 {
     ImNodes::GetIO().LinkDetachWithModifierClick.Modifier = &ImGui::GetIO().KeyCtrl;
-    ImNodes::PushAttributeFlag(ImNodesAttributeFlags_EnableLinkDetachWithDragClick);
     editor.load();
 }
 

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -18,7 +18,6 @@
 #error "Minimum ImGui version requirement not met -- please use a newer version!"
 #endif
 
-#include <algorithm>
 #include <float.h>
 #include <limits.h>
 #include <math.h>
@@ -2087,9 +2086,9 @@ void SetCurrentContext(ImNodesContext* ctx) { GImNodes = ctx; }
 
 ImNodesEditorContext* EditorContextCreate()
 {
-    void*                 mem = ImGui::MemAlloc(sizeof(ImNodesEditorContext));
-    ImNodesEditorContext* editor_ctx = new (mem) ImNodesEditorContext();
-    return editor_ctx;
+    void* mem = ImGui::MemAlloc(sizeof(ImNodesEditorContext));
+    new (mem) ImNodesEditorContext();
+    return (ImNodesEditorContext*)mem;
 }
 
 void EditorContextFree(ImNodesEditorContext* ctx)
@@ -2568,7 +2567,6 @@ void Link(const int id, const int start_attr_id, const int end_attr_id)
 {
     IM_ASSERT(GImNodes->CurrentScope == ImNodesScope_Editor);
 
-    // const int    link_idx = GImNodes->Links.size();
     const ImLink link(id, start_attr_id, end_attr_id, GImNodes->Style.Colors);
     GImNodes->Links.push_back(link);
 }

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1172,7 +1172,7 @@ void PendingStateUpdate(ImNodesContext& context, ImNodesEditorContext& editor)
             }
             else
             {
-                EnterLinkState(context, editor, context.HoveredLinkIdx.Value());
+                EnterLinkState(context, editor, context.Links[context.HoveredLinkIdx.Value()].Id);
             }
             return;
         }

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -993,8 +993,6 @@ void PartialLinkStateUpdate(ImNodesContext& context, ImNodesEditorContext& edito
     // Render the bezier curve
 
     {
-        const ImPinData& start_pin =
-            ObjectPoolFindOrCreateObject(editor.Pins, state.PartialLink.StartPinId);
         const ImVec2               start_pos = start_pin.Pos;
         const ImNodesAttributeType start_pin_type = start_pin.Type;
 

--- a/imnodes.h
+++ b/imnodes.h
@@ -95,10 +95,6 @@ enum ImNodesPinShape_
 enum ImNodesAttributeFlags_
 {
     ImNodesAttributeFlags_None = 0,
-    // Allow detaching a link by left-clicking and dragging the link at a pin it is connected to.
-    // NOTE: the user has to actually delete the link for this to work. A deleted link can be
-    // detected by calling IsLinkDestroyed() after EndNodeEditor().
-    ImNodesAttributeFlags_EnableLinkDetachWithDragClick = 1 << 0,
     // Visual snapping of an in progress link will trigger IsLink Created/Destroyed events. Allows
     // for previewing the creation of a link while dragging it across attributes. See here for demo:
     // https://github.com/Nelarius/imnodes/issues/41#issuecomment-647132113 NOTE: the user has to

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -184,17 +184,28 @@ struct ImPinData
     }
 };
 
-struct ImLinkData
+struct ImLink
 {
-    int Id;
-    int StartPinIdx, EndPinIdx;
+    int   Id;
+    int   StartPinId, EndPinId;
+    ImU32 BaseColor, HoveredColor, SelectedColor;
 
-    struct
+    ImLink(
+        const int id,
+        const int start_pin_id,
+        const int end_pin_id,
+        const unsigned int (&colors)[ImNodesCol_COUNT])
+        : Id(id), StartPinId(start_pin_id), EndPinId(end_pin_id),
+          BaseColor(colors[ImNodesCol_Link]), HoveredColor(colors[ImNodesCol_LinkHovered]),
+          SelectedColor(colors[ImNodesCol_LinkSelected])
     {
-        ImU32 Base, Hovered, Selected;
-    } ColorStyle;
+    }
+};
 
-    ImLinkData(const int link_id) : Id(link_id), StartPinIdx(), EndPinIdx(), ColorStyle() {}
+struct ImCubicBezier
+{
+    ImVec2 P0, P1, P2, P3;
+    int    NumSegments;
 };
 
 struct ImClickInteractionState
@@ -247,7 +258,6 @@ struct ImNodesEditorContext
 {
     ImObjectPool<ImNodeData> Nodes;
     ImObjectPool<ImPinData>  Pins;
-    ImObjectPool<ImLinkData> Links;
 
     ImVector<int> NodeDepthOrder;
 
@@ -264,7 +274,7 @@ struct ImNodesEditorContext
     // Relative origins of selected nodes for snapping of dragged nodes
     ImVector<ImVec2> SelectedNodeOffsets;
     // Offset of the primary node origin relative to the mouse cursor.
-    ImVec2           PrimaryNodeOffset;
+    ImVec2 PrimaryNodeOffset;
 
     ImClickInteractionState ClickInteraction;
 
@@ -283,11 +293,10 @@ struct ImNodesEditorContext
     float  MiniMapScaling;
 
     ImNodesEditorContext()
-        : Nodes(), Pins(), Links(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),
+        : Nodes(), Pins(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),
           SelectedNodeOffsets(), PrimaryNodeOffset(0.f, 0.f), ClickInteraction(),
-          MiniMapEnabled(false), MiniMapSizeFraction(0.0f),
-          MiniMapNodeHoveringCallback(NULL), MiniMapNodeHoveringCallbackUserData(NULL),
-          MiniMapScaling(0.0f)
+          MiniMapEnabled(false), MiniMapSizeFraction(0.0f), MiniMapNodeHoveringCallback(NULL),
+          MiniMapNodeHoveringCallbackUserData(NULL), MiniMapScaling(0.0f)
     {
     }
 };
@@ -307,6 +316,13 @@ struct ImNodesContext
     // Canvas extents
     ImVec2 CanvasOriginScreenSpace;
     ImRect CanvasRectScreenSpace;
+
+    // Frame state
+
+    // Links
+
+    ImVector<ImLink>        Links;
+    ImVector<ImCubicBezier> Curves;
 
     // Debug helpers
     ImNodesScope CurrentScope;

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -269,7 +269,7 @@ struct ImNodesEditorContext
     ImRect GridContentBounds;
 
     ImVector<int> SelectedNodeIndices;
-    ImVector<int> SelectedLinkIndices;
+    ImVector<int> SelectedLinkIds;
 
     // Relative origins of selected nodes for snapping of dragged nodes
     ImVector<ImVec2> SelectedNodeOffsets;
@@ -293,7 +293,7 @@ struct ImNodesEditorContext
     float  MiniMapScaling;
 
     ImNodesEditorContext()
-        : Nodes(), Pins(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),
+        : Nodes(), Pins(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIds(),
           SelectedNodeOffsets(), PrimaryNodeOffset(0.f, 0.f), ClickInteraction(),
           MiniMapEnabled(false), MiniMapSizeFraction(0.0f), MiniMapNodeHoveringCallback(NULL),
           MiniMapNodeHoveringCallbackUserData(NULL), MiniMapScaling(0.0f)


### PR DESCRIPTION
This pr contributes three things:

- Moves links internally from an object pool to a simple vector. This makes links truly immediate-mode.
- Rewrites link, node, pin interaction.
- Removes the attribute flag `EnableLinkDetachWithDragClick`.

@Auburn, if you are still around, wondering if you could give this branch a spin. You’ve been very good at spotting broken interaction code, and this branch rewrites everything 😓 I will leave this pr open for a while while I continue my own tests.

More details about each change below.

### Move links from the object pool to a vector

This change boils down to

```diff
// in `ImNodesEditorContext`
- ImObjectPool<ImLinkData> Links;

// in `ImNodesContext`
+ ImVector<ImLink> Links;
```

When `BeginNodeEditor` is called, the vector is resized to zero. Links are appended to the vector in `ImNodes::Link()`. In `EndNodeEditor`, we render them. Links are now truly immediate-mode and really simple.

Subtle bugs occurring on id reuse, such as this [https://github.com/Nelarius/imnodes/issues/91](https://github.com/Nelarius/imnodes/issues/91) no longer apply to links. The goal is to apply this change for nodes and pins as well.

### Rebuild link, node, pin interaction

- Needed to accommodate the new way of storing links in the interaction code as links are internally identified in a different manner now.
- The existing state machine was difficult to change. This pr introduces a more fine-grained state machine to make the logic of the link interaction states much simpler.

### Remove the EnableLinkDetachWithDragClick attribute flag

- This attribute was removed to simplify the interaction state machine.
- Hovering over pins, links, and nodes can now be made totally exclusive, as we don’t need to detect the link + pin hovered state for this interaction.
- Using the feature felt finicky, as activation required clicking and dragging in the pin hover radius.

## Test checklist

- [x]  IsLinkStarted when partial link started
- [x]  IsLinkDropped when link is dropped
    - [x]  triggers when including_detached_links defined & not from snap
    - [x]  triggers when including_detached_links defined & from snap
    - [x]  does not trigger from snap
    - [x]  triggers when not from snap
- [x]  Repeat IsLinkDropped test with "detach link with modifier" enabled
- [x]  Multi-selecting nodes should not clear link selection
- [x]  Multi-selecting links should not clear node selection
- [ ]  Auto-panning when dragging nodes
- [ ]  Auto-panning when box-selecting nodes
- [ ]  Auto-panning when dragging links
- [ ]  Minimap viewport interaction
    - [ ]  Clicking minimap node centers on node
    - [ ]  Dragging viewport in minimap
- [ ]  Minimap renders selected nodes
- [ ]  Clicking and dragging nodes on top of minimap
- [ ]  Dragging links on top of minimap