### PR TITLE
Customizable ID type

### DIFF
--- a/IMNODES_NAMESPACE.h
+++ b/IMNODES_NAMESPACE.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef IMNODES_NAMESPACE
+#define IMNODES_NAMESPACE ImNodes
+#endif

--- a/ImGuiStorage.h
+++ b/ImGuiStorage.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "IMNODES_NAMESPACE.h"
+#include "imnodes_config_or_default.h"
+
+namespace IMNODES_NAMESPACE
+{
+namespace Internal
+{
+
+// Copy-pasted from ImGui because we needed to change the ID type
+
+// Helper: Key->Value storage
+// Typically you don't have to worry about this since a storage is held within each Window.
+// We use it to e.g. store collapse state for a tree (Int 0/1)
+// This is optimized for efficient lookup (dichotomy into a contiguous buffer) and rare insertion
+// (typically tied to user interactions aka max once a frame) You can use it as custom user storage
+// for temporary values. Declare your own storage if, for example:
+// - You want to manipulate the open/close state of a particular sub-tree in your interface (tree
+// node uses Int 0/1 to store their state).
+// - You want to store custom debug data easily without adding or editing structures in your code
+// (probably not efficient, but convenient) Types are NOT stored, so it is up to you to make sure
+// your Key don't collide with different types.
+struct Storage
+{
+    // [Internal]
+    struct ImGuiStoragePair
+    {
+        ID key;
+        union
+        {
+            int   val_i;
+            float val_f;
+            void* val_p;
+        };
+        ImGuiStoragePair(ID _key, int _val_i)
+        {
+            key = _key;
+            val_i = _val_i;
+        }
+        ImGuiStoragePair(ID _key, float _val_f)
+        {
+            key = _key;
+            val_f = _val_f;
+        }
+        ImGuiStoragePair(ID _key, void* _val_p)
+        {
+            key = _key;
+            val_p = _val_p;
+        }
+    };
+
+    ImVector<ImGuiStoragePair> Data;
+
+    // - Get***() functions find pair, never add/allocate. Pairs are sorted so a query is O(log N)
+    // - Set***() functions find pair, insertion on demand if missing.
+    // - Sorted insertion is costly, paid once. A typical frame shouldn't need to insert any new
+    // pair.
+    void            Clear() { Data.clear(); }
+    IMGUI_API int   GetInt(ID key, int default_val = 0) const;
+    IMGUI_API void  SetInt(ID key, int val);
+    IMGUI_API bool  GetBool(ID key, bool default_val = false) const;
+    IMGUI_API void  SetBool(ID key, bool val);
+    IMGUI_API float GetFloat(ID key, float default_val = 0.0f) const;
+    IMGUI_API void  SetFloat(ID key, float val);
+    IMGUI_API void* GetVoidPtr(ID key) const; // default_val is NULL
+    IMGUI_API void  SetVoidPtr(ID key, void* val);
+
+    // - Get***Ref() functions finds pair, insert on demand if missing, return pointer. Useful if
+    // you intend to do Get+Set.
+    // - References are only valid until a new value is added to the storage. Calling a Set***()
+    // function or a Get***Ref() function invalidates the pointer.
+    // - A typical use case where this is convenient for quick hacking (e.g. add storage during a
+    // live Edit&Continue session if you can't modify existing struct)
+    //      float* pvar = ImGui::GetFloatRef(key); ImGui::SliderFloat("var", pvar, 0, 100.0f);
+    //      some_var += *pvar;
+    IMGUI_API int*   GetIntRef(ID key, int default_val = 0);
+    IMGUI_API bool*  GetBoolRef(ID key, bool default_val = false);
+    IMGUI_API float* GetFloatRef(ID key, float default_val = 0.0f);
+    IMGUI_API void** GetVoidPtrRef(ID key, void* default_val = NULL);
+
+    // Use on your own storage if you know only integer are being stored (open/close all tree nodes)
+    IMGUI_API void SetAllInt(int val);
+
+    // For quicker full rebuild of a storage (instead of an incremental one), you may add all your
+    // contents and then sort once.
+    IMGUI_API void BuildSortByKey();
+};
+
+} // namespace Internal
+} // namespace IMNODES_NAMESPACE

--- a/imnodes.h
+++ b/imnodes.h
@@ -3,13 +3,9 @@
 #include <stddef.h>
 #include <imgui.h>
 
-#ifdef IMNODES_USER_CONFIG
-#include IMNODES_USER_CONFIG
-#endif
+#include "imnodes_config_or_default.h"
 
-#ifndef IMNODES_NAMESPACE
-#define IMNODES_NAMESPACE ImNodes
-#endif
+#include "IMNODES_NAMESPACE.h"
 
 typedef int ImNodesCol;             // -> enum ImNodesCol_
 typedef int ImNodesStyleVar;        // -> enum ImNodesStyleVar_
@@ -230,7 +226,7 @@ struct ImNodesEditorContext;
 
 // Callback type used to specify special behavior when hovering a node in the minimap
 #ifndef ImNodesMiniMapNodeHoveringCallback
-typedef void (*ImNodesMiniMapNodeHoveringCallback)(int, void*);
+typedef void (*ImNodesMiniMapNodeHoveringCallback)(IMNODES_NAMESPACE::ID, void*);
 #endif
 
 #ifndef ImNodesMiniMapNodeHoveringCallbackUserData
@@ -253,7 +249,7 @@ void                  EditorContextFree(ImNodesEditorContext*);
 void                  EditorContextSet(ImNodesEditorContext*);
 ImVec2                EditorContextGetPanning();
 void                  EditorContextResetPanning(const ImVec2& pos);
-void                  EditorContextMoveToNode(const int node_id);
+void                  EditorContextMoveToNode(const ID node_id);
 
 ImNodesIO& GetIO();
 
@@ -285,11 +281,10 @@ void PushStyleVar(ImNodesStyleVar style_item, float value);
 void PushStyleVar(ImNodesStyleVar style_item, const ImVec2& value);
 void PopStyleVar(int count = 1);
 
-// id can be any positive or negative integer, but INT_MIN is currently reserved for internal use.
-void BeginNode(int id);
+void BeginNode(ID id);
 void EndNode();
 
-ImVec2 GetNodeDimensions(int id);
+ImVec2 GetNodeDimensions(ID id);
 
 // Place your node title bar content (such as the node title, using ImGui::Text) between the
 // following function calls. These functions have to be called before adding any attributes, or the
@@ -307,15 +302,15 @@ void EndNodeTitleBar();
 // Each attribute id must be unique.
 
 // Create an input attribute block. The pin is rendered on left side.
-void BeginInputAttribute(int id, ImNodesPinShape shape = ImNodesPinShape_CircleFilled);
+void BeginInputAttribute(ID id, ImNodesPinShape shape = ImNodesPinShape_CircleFilled);
 void EndInputAttribute();
 // Create an output attribute block. The pin is rendered on the right side.
-void BeginOutputAttribute(int id, ImNodesPinShape shape = ImNodesPinShape_CircleFilled);
+void BeginOutputAttribute(ID id, ImNodesPinShape shape = ImNodesPinShape_CircleFilled);
 void EndOutputAttribute();
 // Create a static attribute block. A static attribute has no pin, and therefore can't be linked to
 // anything. However, you can still use IsAttributeActive() and IsAnyAttributeActive() to check for
 // attribute activity.
-void BeginStaticAttribute(int id);
+void BeginStaticAttribute(ID id);
 void EndStaticAttribute();
 
 // Push a single AttributeFlags value. By default, only AttributeFlags_None is set.
@@ -325,10 +320,10 @@ void PopAttributeFlag();
 // Render a link between attributes.
 // The attributes ids used here must match the ids used in Begin(Input|Output)Attribute function
 // calls. The order of start_attr and end_attr doesn't make a difference for rendering the link.
-void Link(int id, int start_attribute_id, int end_attribute_id);
+void Link(ID id, ID start_attribute_id, ID end_attribute_id);
 
 // Enable or disable the ability to click and drag a specific node.
-void SetNodeDraggable(int node_id, const bool draggable);
+void SetNodeDraggable(ID node_id, const bool draggable);
 
 // The node's position can be expressed in three coordinate systems:
 // * screen space coordinates, -- the origin is the upper left corner of the window.
@@ -339,16 +334,16 @@ void SetNodeDraggable(int node_id, const bool draggable);
 
 // Use the following functions to get and set the node's coordinates in these coordinate systems.
 
-void SetNodeScreenSpacePos(int node_id, const ImVec2& screen_space_pos);
-void SetNodeEditorSpacePos(int node_id, const ImVec2& editor_space_pos);
-void SetNodeGridSpacePos(int node_id, const ImVec2& grid_pos);
+void SetNodeScreenSpacePos(ID node_id, const ImVec2& screen_space_pos);
+void SetNodeEditorSpacePos(ID node_id, const ImVec2& editor_space_pos);
+void SetNodeGridSpacePos(ID node_id, const ImVec2& grid_pos);
 
-ImVec2 GetNodeScreenSpacePos(const int node_id);
-ImVec2 GetNodeEditorSpacePos(const int node_id);
-ImVec2 GetNodeGridSpacePos(const int node_id);
+ImVec2 GetNodeScreenSpacePos(const ID node_id);
+ImVec2 GetNodeEditorSpacePos(const ID node_id);
+ImVec2 GetNodeGridSpacePos(const ID node_id);
 
 // If ImNodesStyleFlags_GridSnapping is enabled, snap the specified node's origin to the grid.
-void SnapNodeToGrid(int node_id);
+void SnapNodeToGrid(ID node_id);
 
 // Returns true if the current node editor canvas is being hovered over by the mouse, and is not
 // blocked by any other windows.
@@ -356,9 +351,9 @@ bool IsEditorHovered();
 // The following functions return true if a UI element is being hovered over by the mouse cursor.
 // Assigns the id of the UI element being hovered over to the function argument. Use these functions
 // after EndNodeEditor() has been called.
-bool IsNodeHovered(int* node_id);
-bool IsLinkHovered(int* link_id);
-bool IsPinHovered(int* attribute_id);
+bool IsNodeHovered(ID* node_id);
+bool IsLinkHovered(ID* link_id);
+bool IsPinHovered(ID* attribute_id);
 
 // Use The following two functions to query the number of selected nodes or links in the current
 // editor. Use after calling EndNodeEditor().
@@ -367,8 +362,8 @@ int NumSelectedLinks();
 // Get the selected node/link ids. The pointer argument should point to an integer array with at
 // least as many elements as the respective NumSelectedNodes/NumSelectedLinks function call
 // returned.
-void GetSelectedNodes(int* node_ids);
-void GetSelectedLinks(int* link_ids);
+void GetSelectedNodes(ID* node_ids);
+void GetSelectedLinks(ID* link_ids);
 // Clears the list of selected nodes/links. Useful if you want to delete a selected node or link.
 void ClearNodeSelection();
 void ClearLinkSelection();
@@ -378,46 +373,46 @@ void ClearLinkSelection();
 // Clear-functions has the precondition that the object is currently considered selected.
 // Preconditions listed above can be checked via IsNodeSelected/IsLinkSelected if not already
 // known.
-void SelectNode(int node_id);
-void ClearNodeSelection(int node_id);
-bool IsNodeSelected(int node_id);
-void SelectLink(int link_id);
-void ClearLinkSelection(int link_id);
-bool IsLinkSelected(int link_id);
+void SelectNode(ID node_id);
+void ClearNodeSelection(ID node_id);
+bool IsNodeSelected(ID node_id);
+void SelectLink(ID link_id);
+void ClearLinkSelection(ID link_id);
+bool IsLinkSelected(ID link_id);
 
 // Was the previous attribute active? This will continuously return true while the left mouse button
 // is being pressed over the UI content of the attribute.
 bool IsAttributeActive();
 // Was any attribute active? If so, sets the active attribute id to the output function argument.
-bool IsAnyAttributeActive(int* attribute_id = NULL);
+bool IsAnyAttributeActive(ID* attribute_id = NULL);
 
 // Use the following functions to query a change of state for an existing link, or new link. Call
 // these after EndNodeEditor().
 
 // Did the user start dragging a new link from a pin?
-bool IsLinkStarted(int* started_at_attribute_id);
+bool IsLinkStarted(ID* started_at_attribute_id);
 // Did the user drop the dragged link before attaching it to a pin?
 // There are two different kinds of situations to consider when handling this event:
 // 1) a link which is created at a pin and then dropped
 // 2) an existing link which is detached from a pin and then dropped
 // Use the including_detached_links flag to control whether this function triggers when the user
 // detaches a link and drops it.
-bool IsLinkDropped(int* started_at_attribute_id = NULL, bool including_detached_links = true);
+bool IsLinkDropped(ID* started_at_attribute_id = NULL, bool including_detached_links = true);
 // Did the user finish creating a new link?
 bool IsLinkCreated(
-    int*  started_at_attribute_id,
-    int*  ended_at_attribute_id,
+    ID*   started_at_attribute_id,
+    ID*   ended_at_attribute_id,
     bool* created_from_snap = NULL);
 bool IsLinkCreated(
-    int*  started_at_node_id,
-    int*  started_at_attribute_id,
-    int*  ended_at_node_id,
-    int*  ended_at_attribute_id,
+    ID*   started_at_node_id,
+    ID*   started_at_attribute_id,
+    ID*   ended_at_node_id,
+    ID*   ended_at_attribute_id,
     bool* created_from_snap = NULL);
 
 // Was an existing link detached from a pin by the user? The detached link's id is assigned to the
 // output argument link_id.
-bool IsLinkDestroyed(int* link_id);
+bool IsLinkDestroyed(ID* link_id);
 
 // Use the following functions to write the editor context's state to a string, or directly to a
 // file. The editor context is serialized in the INI file format.

--- a/imnodes_config_or_default.h
+++ b/imnodes_config_or_default.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "IMNODES_NAMESPACE.h"
+
+#ifdef IMNODES_USER_CONFIG
+#include "imnodes_config.h"
+#else
+
+#include <limits.h>
+#include <string>
+
+namespace IMNODES_NAMESPACE
+{
+// id can be any positive or negative integer, but INT_MIN is currently reserved for internal use.
+using ID = int;
+static constexpr ID INVALID_ID = INT_MIN;
+
+inline void PushID(ID id) { ImGui::PushID(id); }
+
+inline std::string IDToString(ID id) { return std::to_string(id); }
+
+inline ID IDFromString(const std::string& str) { return std::stoi(str); }
+
+} // namespace IMNODES_NAMESPACE
+
+#endif


### PR DESCRIPTION
Hi 👋
In my application I have a use case where I use 128-bits UUIDs as IDs internally, and I would like to use these same IDs as Node and Link IDs when I use *imnodes* without having to truncate to `int` back and forth.

This is why I basically added `using ID = int;` to *imnodes*, and added the possibility to override that definition of `ID` inside "imnodes_config.h".

A user-defined "imnodes_config.h" would look like this:
```cpp
// imnodes_config.h
#pragma once
#include <limits.h>
#include <string>

namespace IMNODES_NAMESPACE
{
using ID = int;
static constexpr ID INVALID_ID = INT_MIN;

inline void PushID(ID id) { ImGui::PushID(id); }

inline std::string IDToString(ID id) { return std::to_string(id); }

inline ID IDFromString(const std::string& str) { return std::stoi(str); }

} // namespace IMNODES_NAMESPACE
```

### Changes

The two main (and maybe controversial) changes I hade to make are:
- [ ] Having to copy-paste `ImGuiStorage`'s implementation from *Dear ImGui* into *imnodes* just to change the type of the ID used to index into that storage. But this also has the benefit of removing the `static_cast`s from `int` to `ImGuiID` that were all over *imnodes*' implementation.
- [ ] Changing the implementation of `NodeLineHandler()` that is used during serialization of the editor state. We now use `std::string` manipulations instead of `sscanf` to read and write the `ID` to and from strings. That is because we don't know how complex the user ID might be, and we have to let them handle the conversions. Using `std::string` instead of `char[]` is the simplest.