### PR TITLE
Fixes mismatched OutputAttribute in color example

### DIFF
--- a/example/color_node_editor.cpp
+++ b/example/color_node_editor.cpp
@@ -514,7 +514,7 @@ public:
                     const float label_width = ImGui::CalcTextSize("output").x;
                     ImGui::Indent(node_width - label_width);
                     ImGui::TextUnformatted("output");
-                    ImNodes::EndInputAttribute();
+                    ImNodes::EndOutputAttribute();
                 }
 
                 ImNodes::EndNode();


### PR DESCRIPTION
This PR just fixes what appears to be a (currently harmless) typo. It doesn't introduce any functional difference, given that EndInputAttribute() and EndOutputAttribute() both just call EndPinAttribute(), but if those semantics ever changed, it could cause an issue.