### PR TITLE
Fix CMake config to allow using imnodes as sub project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 # cmake options
 option(IMNODES_EXAMPLES "Build examples" ${IMNODES_STANDALONE_PROJECT})
 
-# allow custom imgui target name since this can vary because imgui doesn''
+# allow custom imgui target name since this can vary because imgui doesn't natively include a CMakeLists.txt
 if(NOT DEFINED IMNODES_IMGUI_TARGET_NAME)
     find_package(imgui CONFIG REQUIRED)
     set(IMNODES_IMGUI_TARGET_NAME imgui::imgui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,25 @@ project(imnodes)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-find_package(imgui CONFIG REQUIRED)
-find_package(SDL2 CONFIG REQUIRED)
+
+# determine whether this is a standalone project or included by other projects
+if (NOT DEFINED IMNODES_STANDALONE_PROJECT)
+    if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+        set(IMNODES_STANDALONE_PROJECT ON)
+    else()
+        set(IMNODES_STANDALONE_PROJECT OFF)
+    endif ()
+endif()
+
+# cmake options
+option(IMNODES_EXAMPLES "Build examples" ${IMNODES_STANDALONE_PROJECT})
+
+# allow custom imgui target name since this can vary because imgui doesn''
+if(NOT DEFINED IMNODES_IMGUI_TARGET_NAME)
+    find_package(imgui CONFIG REQUIRED)
+    set(IMNODES_IMGUI_TARGET_NAME imgui::imgui)
+endif()
+
 
 if(MSVC)
     add_compile_definitions(SDL_MAIN_HANDLED)
@@ -22,59 +39,63 @@ target_sources(imnodes PRIVATE
     imnodes.h
     imnodes_internal.h
     imnodes.cpp)
-target_include_directories(imnodes PUBLIC ${CMAKE_SOURCE_DIR})
-target_link_libraries(imnodes PUBLIC imgui::imgui)
+target_include_directories(imnodes PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(imnodes PUBLIC ${IMNODES_IMGUI_TARGET_NAME})
 
 # Example projects
+if(IMNODES_EXAMPLES)
 
-add_executable(colornode
-    ${CMAKE_SOURCE_DIR}/imnodes.cpp
-    ${CMAKE_SOURCE_DIR}/example/main.cpp
-    ${CMAKE_SOURCE_DIR}/example/color_node_editor.cpp)
-target_link_libraries(colornode imnodes SDL2::SDL2)
-if (APPLE)
-    target_link_libraries(colornode "-framework OpenGL")
-elseif(MSVC)
-    target_link_libraries(colornode "opengl32")
-else()
-    target_link_libraries(colornode X11 Xext GL)
-endif()
+    find_package(SDL2 CONFIG REQUIRED)
 
-add_executable(multieditor
-    ${CMAKE_SOURCE_DIR}/imnodes.cpp 
-    ${CMAKE_SOURCE_DIR}/example/main.cpp
-    ${CMAKE_SOURCE_DIR}/example/multi_editor.cpp)
-target_link_libraries(multieditor imnodes SDL2::SDL2)
-if (APPLE)
-    target_link_libraries(multieditor "-framework OpenGL")
-elseif(MSVC)
-    target_link_libraries(multieditor "opengl32")
-else()
-    target_link_libraries(multieditor X11 Xext GL)
-endif()
+    add_executable(colornode
+        ${CMAKE_CURRENT_SOURCE_DIR}/imnodes.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/main.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/color_node_editor.cpp)
+    target_link_libraries(colornode imnodes SDL2::SDL2)
+    if (APPLE)
+        target_link_libraries(colornode "-framework OpenGL")
+    elseif(MSVC)
+        target_link_libraries(colornode "opengl32")
+    else()
+        target_link_libraries(colornode X11 Xext GL)
+    endif()
 
-add_executable(saveload
-    ${CMAKE_SOURCE_DIR}/imnodes.cpp
-    ${CMAKE_SOURCE_DIR}/example/main.cpp
-    ${CMAKE_SOURCE_DIR}/example/save_load.cpp)
-target_link_libraries(saveload imnodes SDL2::SDL2)
-if (APPLE)
-    target_link_libraries(saveload "-framework OpenGL")
-elseif(MSVC)
-    target_link_libraries(saveload "opengl32")
-else()
-    target_link_libraries(saveload X11 Xext GL)
-endif()
+    add_executable(multieditor
+        ${CMAKE_CURRENT_SOURCE_DIR}/imnodes.cpp 
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/main.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/multi_editor.cpp)
+    target_link_libraries(multieditor imnodes SDL2::SDL2)
+    if (APPLE)
+        target_link_libraries(multieditor "-framework OpenGL")
+    elseif(MSVC)
+        target_link_libraries(multieditor "opengl32")
+    else()
+        target_link_libraries(multieditor X11 Xext GL)
+    endif()
 
-add_executable(hello
-    ${CMAKE_SOURCE_DIR}/imnodes.cpp
-    ${CMAKE_SOURCE_DIR}/example/main.cpp
-    ${CMAKE_SOURCE_DIR}/example/hello.cpp)
-target_link_libraries(hello imnodes SDL2::SDL2)
-if (APPLE)
-    target_link_libraries(hello "-framework OpenGL")
-elseif(MSVC)
-    target_link_libraries(hello "opengl32")
-else()
-    target_link_libraries(hello X11 Xext GL)
+    add_executable(saveload
+        ${CMAKE_CURRENT_SOURCE_DIR}/imnodes.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/main.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/save_load.cpp)
+    target_link_libraries(saveload imnodes SDL2::SDL2)
+    if (APPLE)
+        target_link_libraries(saveload "-framework OpenGL")
+    elseif(MSVC)
+        target_link_libraries(saveload "opengl32")
+    else()
+        target_link_libraries(saveload X11 Xext GL)
+    endif()
+
+    add_executable(hello
+        ${CMAKE_CURRENT_SOURCE_DIR}/imnodes.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/main.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/example/hello.cpp)
+    target_link_libraries(hello imnodes SDL2::SDL2)
+    if (APPLE)
+        target_link_libraries(hello "-framework OpenGL")
+    elseif(MSVC)
+        target_link_libraries(hello "opengl32")
+    else()
+        target_link_libraries(hello X11 Xext GL)
+    endif()
 endif()

--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -6,11 +6,7 @@
 // [SECTION] render helpers
 // [SECTION] API implementation
 
-#include "imnodes.h"
 #include "imnodes_internal.h"
-
-#define IMGUI_DEFINE_MATH_OPERATORS
-#include <imgui_internal.h>
 
 // Check minimum ImGui version
 #define MINIMUM_COMPATIBLE_IMGUI_VERSION 17400

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "imnodes.h"
-
-#include <imgui.h>
 #define IMGUI_DEFINE_MATH_OPERATORS
+#include <imgui.h>
 #include <imgui_internal.h>
+
+#include "imnodes.h"
 
 #include <limits.h>
 


### PR DESCRIPTION
- Swap uses of `CMAKE_SOURCE_DIR` for `CMAKE_CURRENT_SOURCE_DIR`
- Detect if running as a sub project
- Add option to build examples, defaults to off if running as a subproject
- Allow custom imgui target name since this can vary because imgui doesn't natively include a CMakeLists.txt