### PR TITLE
Added callback functions for Grab/Release Node events handling

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -823,9 +823,9 @@ ImVec2 SnapOriginToGrid(ImVec2 origin)
     return origin;
 }
 
-void TranslateSelectedNodes(ImNodesEditorContext& editor)
+void TranslateSelectedNodes(ImNodesEditorContext& editor, bool force)
 {
-    if (GImNodes->LeftMouseDragging)
+    if (force || GImNodes->LeftMouseDragging)
     {
         // If we have grid snap enabled, don't start moving nodes until we've moved the mouse
         // slightly
@@ -984,11 +984,19 @@ void ClickInteractionUpdate(ImNodesEditorContext& editor)
     break;
     case ImNodesClickInteractionType_Node:
     {
-        TranslateSelectedNodes(editor);
+        if (!editor.NodeDraggingEnableStateOnce)
+        {
+            IM_ASSERT(GImNodes->HoveredNodeIdx.HasValue());
+            editor.NodeDraggingEnableStateOnce = true;
+            editor.NodeDraggingState = 1;
+        }
+
+        TranslateSelectedNodes(editor, false);
 
         if (GImNodes->LeftMouseReleased)
         {
             editor.ClickInteraction.Type = ImNodesClickInteractionType_None;
+            editor.NodeDraggingEnableStateOnce = false;
         }
     }
     break;
@@ -2244,6 +2252,11 @@ void BeginNodeEditor()
 
     GImNodes->ActiveAttribute = false;
 
+    if (editor.ClickInteraction.Type == ImNodesClickInteractionType_Node && GImNodes->LeftMouseReleased)
+    {
+        editor.NodeDraggingState = 2;
+    }
+
     ImGui::BeginGroup();
     {
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(1.f, 1.f));
@@ -2281,6 +2294,8 @@ void EndNodeEditor()
     GImNodes->CurrentScope = ImNodesScope_None;
 
     ImNodesEditorContext& editor = EditorContextGet();
+
+    editor.NodeDraggingState = 0;
 
     bool no_grid_content = editor.GridContentBounds.IsInverted();
     if (no_grid_content)
@@ -2953,6 +2968,32 @@ bool IsAnyAttributeActive(int* const attribute_id)
     }
 
     return true;
+}
+
+bool IsNodesDragStarted(int *num_selected_nodes)
+{
+    ImNodesEditorContext &editor = *GImNodes->EditorCtx;
+
+    if (editor.NodeDraggingState == 1)
+    {
+        *num_selected_nodes = editor.SelectedNodeIndices.size();
+        return true;
+    }
+
+    return false;
+}
+
+bool IsNodesDragStopped(int *num_selected_nodes)
+{
+    ImNodesEditorContext &editor = *GImNodes->EditorCtx;
+
+    if (editor.NodeDraggingState == 2)
+    {
+        *num_selected_nodes = editor.SelectedNodeIndices.size();
+        TranslateSelectedNodes(editor, true);
+        return true;
+    }
+    return false;
 }
 
 bool IsLinkStarted(int* const started_at_id)

--- a/imnodes.h
+++ b/imnodes.h
@@ -394,6 +394,11 @@ bool IsAnyAttributeActive(int* attribute_id = NULL);
 // Use the following functions to query a change of state for an existing link, or new link. Call
 // these after EndNodeEditor().
 
+// Returns true if the user just started dragging a node
+bool IsNodesDragStarted(int *num_selected_nodes);
+// Returns true if the user just stopped (released) the node after dragging it
+bool IsNodesDragStopped(int *num_selected_nodes);
+
 // Did the user start dragging a new link from a pin?
 bool IsLinkStarted(int* started_at_attribute_id);
 // Did the user drop the dragged link before attaching it to a pin?

--- a/imnodes_internal.h
+++ b/imnodes_internal.h
@@ -267,6 +267,8 @@ struct ImNodesEditorContext
     ImVec2           PrimaryNodeOffset;
 
     ImClickInteractionState ClickInteraction;
+    int NodeDraggingState; // 0 - None, 1 - Just started dragging, 2 - Just stopped dragging
+    bool NodeDraggingEnableStateOnce; // Used as a flag that ensures state value change for a single frame
 
     // Mini-map state set by MiniMap()
 
@@ -284,7 +286,7 @@ struct ImNodesEditorContext
 
     ImNodesEditorContext()
         : Nodes(), Pins(), Links(), Panning(0.f, 0.f), SelectedNodeIndices(), SelectedLinkIndices(),
-          SelectedNodeOffsets(), PrimaryNodeOffset(0.f, 0.f), ClickInteraction(),
+          SelectedNodeOffsets(), PrimaryNodeOffset(0.f, 0.f), ClickInteraction(), NodeDraggingState(0), NodeDraggingEnableStateOnce(false),
           MiniMapEnabled(false), MiniMapSizeFraction(0.0f),
           MiniMapNodeHoveringCallback(NULL), MiniMapNodeHoveringCallbackUserData(NULL),
           MiniMapScaling(0.0f)


### PR DESCRIPTION
Fixes #168

Usage:

```cpp
ImNodes::BeginNodeEditor();

// ...

// Creating nodes each frame from state arrays
for (int i = 0; i < graph.nodes.size(); i++)
{
    const int id = graph.nodes[i];
    const float node_x = graph.nodes_x[i];
    const float node_y = graph.nodes_y[i];

    ImNodes::BeginNode(id);
    ImNodes::SetNodeGridSpacePos(id, ImVec2(node_x, node_y));
    ImNodes::EndNode();
}

// ...

int num_selected_nodes;

if (ImNodes::IsNodesDragStarted(&num_selected_nodes))
{
    std::vector<int> selected_nodes(num_selected_nodes);
    ImNodes::GetSelectedNodes(selected_nodes.data());

    for (int i = 0; i < selected_nodes.size(); i++)
    {
        const int id = selected_nodes[i];
        printf("Node was just grabbed %d\n", id);
    }
}

if (ImNodes::IsNodesDragStopped(&num_selected_nodes))
{
    std::vector<int> selected_nodes(num_selected_nodes);
    ImNodes::GetSelectedNodes(selected_nodes.data());

    for (int i = 0; i < selected_nodes.size(); i++)
    {
        const int id = selected_nodes[i];
        printf("Node was just released %d\n", id);
        // Store nodes changed positions here
        // const ImVec2 &new_node_pos = ImNodes::GetNodeGridSpacePos(id);
    }
}

// ...

ImNodes::EndNodeEditor();

```