### PR TITLE
fix: node graph pans and starts box selection after focusing on another window

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -724,7 +724,7 @@ void BeginCanvasInteraction(ImNodesEditorContext& editor)
     const bool mouse_not_in_canvas = !MouseInCanvas();
 
     if (editor.ClickInteraction.Type != ImNodesClickInteractionType_None ||
-        any_ui_element_hovered || mouse_not_in_canvas)
+        any_ui_element_hovered || mouse_not_in_canvas || !ImGui::IsWindowHovered())
     {
         return;
     }


### PR DESCRIPTION
Closes #170. I've been testing it locally for a couple days and noticed no regressions, but my use-case is constrained to a fullscreen window with the node editor and windows floating on top of it.