### PR TITLE
Fix AddRect call for Dear ImGui 1.92.8

### DIFF
--- a/imnodes.cpp
+++ b/imnodes.cpp
@@ -1556,7 +1556,7 @@ void DrawNode(ImNodesEditorContext& editor, const int node_idx)
                 node.LayoutStyle.CornerRounding,
                 ImDrawCornerFlags_All,
                 node.LayoutStyle.BorderThickness);
-#else
+#elif IMGUI_VERSION_NUM < 19276
             GImNodes->CanvasDrawList->AddRect(
                 node.Rect.Min,
                 node.Rect.Max,
@@ -1564,6 +1564,14 @@ void DrawNode(ImNodesEditorContext& editor, const int node_idx)
                 node.LayoutStyle.CornerRounding,
                 ImDrawFlags_RoundCornersAll,
                 node.LayoutStyle.BorderThickness);
+#else
+            GImNodes->CanvasDrawList->AddRect(
+                node.Rect.Min,
+                node.Rect.Max,
+                node.ColorStyle.Outline,
+                node.LayoutStyle.CornerRounding,
+                node.LayoutStyle.BorderThickness,
+                ImDrawFlags_RoundCornersAll);
 #endif
         }
     }


### PR DESCRIPTION
Dear ImGui 1.92.8 reordered the AddRect thickness/flags arguments and deletes the old overload. Guard the imnodes call so older ImGui versions keep the old order and 1.92.8+ uses the new one.

Verified through the cimgui-pack combined build.